### PR TITLE
Adds sqlite native code for MacOS

### DIFF
--- a/src/AP.CopyFiles.targets
+++ b/src/AP.CopyFiles.targets
@@ -19,12 +19,16 @@
     <XmlPeek Query="packages/package[@id='SQLitePCLRaw.lib.e_sqlite3.linux']/@*[name()='id' or name()='version']" XmlInputPath="packages.config">
       <Output TaskParameter="Result" ItemName="SqliteLinuxPackageFragments" />
     </XmlPeek>
+    <XmlPeek Query="packages/package[@id='SQLitePCLRaw.lib.e_sqlite3.osx']/@*[name()='id' or name()='version']" XmlInputPath="packages.config">
+      <Output TaskParameter="Result" ItemName="SqliteOsxPackageFragments" />
+    </XmlPeek>
     <PropertyGroup>
       <SqliteLinuxPackage>@(SqliteLinuxPackageFragments, '.')</SqliteLinuxPackage>
+      <SqliteOsxPackage>@(SqliteOsxPackageFragments, '.')</SqliteOsxPackage>
     </PropertyGroup>
-    <Message Text="[APCopyFilesAfterBuild]: Xml found: $(SqliteLinuxPackage). Searching for linux sqlite native code..." Importance="High" />
+    <Message Text="[APCopyFilesAfterBuild]: Xml found: $(SqliteLinuxPackage), $(SqliteOsxPackage). Searching for linux/osx sqlite native code..." Importance="High" />
     <ItemGroup>
-      <SqliteNativeFiles Include="..\..\packages\$(SqliteLinuxPackage)\runtimes\**\*.*" />
+      <SqliteNativeFiles Include="..\..\packages\$(SqliteLinuxPackage)\runtimes\**\*.*;..\..\packages\$(SqliteOsxPackage)\runtimes\**\*.*" />
     </ItemGroup>
     <Message Text="[APCopyFilesAfterBuild]: Found @(SqliteNativeFiles). Copying native code to libruntimes" Importance="High" />
     <Copy SourceFiles="@(SqliteNativeFiles)" DestinationFolder="$(OutputPath)\\libruntimes\\%(RecursiveDir)" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" Retries="3" RetryDelayMilliseconds="300" />

--- a/src/AnalysisPrograms/SQLitePCLRaw.provider.e_sqlite3.dll.config
+++ b/src/AnalysisPrograms/SQLitePCLRaw.provider.e_sqlite3.dll.config
@@ -9,4 +9,5 @@
   <dllmap os="linux" cpu="x86,x86-64" wordsize="32" dll="e_sqlite3" target="runtimes/linux-x32/native/libe_sqlite3.so" />
   <dllmap os="linux" cpu="arm" dll="e_sqlite3" target="runtimes/linux-arm/native/libe_sqlite3.so" />
   <dllmap os="linux" cpu="armv8" dll="e_sqlite3" target="runtimes/linux-armel/native/libe_sqlite3.so" />
+  <dllmap os="osx" cpu="x86-64" dll="e_sqlite3" target="runtimes/osx-x64/native/libe_sqlite3.dylib" />
 </configuration>

--- a/tests/Acoustics.Test/Acoustics.Test.csproj
+++ b/tests/Acoustics.Test/Acoustics.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\MSTest.TestAdapter.1.3.0-beta2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.3.0-beta2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -79,10 +79,10 @@
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.1.3.0-beta2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.1.3.0-beta2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
@@ -283,6 +283,7 @@
     <Compile Include="AudioAnalysisTools\TileImage\TilerTests.cs" />
     <Compile Include="AudioAnalysisTools\LongDurationSpectrograms\Zooming\ZoomTiledSpectrogramTests.cs" />
     <Compile Include="DotNetVersionTests.cs" />
+    <Compile Include="RuntimesTests.cs" />
     <Compile Include="Shared\ConfigTests.cs" />
     <Compile Include="Shared\ProcessRunnerTests.cs" />
     <Compile Include="Shared\RangeTests.cs" />
@@ -422,19 +423,19 @@
     <Error Condition="!Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets'))" />
     <Error Condition="!Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.3.0-beta2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.3.0-beta2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.3.0-beta2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.3.0-beta2\build\net45\MSTest.TestAdapter.targets'))" />
     <Error Condition="!Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets'))" />
     <Error Condition="!Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets'))" />
     <Error Condition="!Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets'))" />
     <Error Condition="!Exists('..\..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Accord.3.8.0\build\Accord.targets'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Import Project="..\..\packages\MSTest.TestAdapter.1.3.0-beta2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.3.0-beta2\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets" Condition="Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" />
   <Import Project="..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
   <Import Project="..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.9\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
   <Import Project="..\..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\..\packages\Accord.3.8.0\build\Accord.targets')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Acoustics.Test/RuntimesTests.cs
+++ b/tests/Acoustics.Test/RuntimesTests.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="RuntimesTests.cs" company="QutEcoacoustics">
+// All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
+// </copyright>
+
+namespace Acoustics.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using TestHelpers;
+
+    [TestClass]
+    public class RuntimesTests
+    {
+        public RuntimesTests()
+        {
+        }
+
+        [TestMethod]
+        public void TestRequiredDllsCopiedToBuildDir()
+        {
+            var buildDir = TestHelpers.PathHelper.AnalysisProgramsBuild;
+
+            Assert.That.DirectoryExists(buildDir);
+
+            var runtimeDir = Path.Combine(buildDir, "libruntimes");
+
+            var expected = new string[]
+            {
+                "linux-arm/native/libe_sqlite3.so",
+                "linux-armel/native/libe_sqlite3.so",
+                "linux-x64/native/libe_sqlite3.so",
+                "linux-x86/native/libe_sqlite3.so",
+                "osx-x64/native/libe_sqlite3.dylib",
+            };
+
+            foreach (var directory in expected)
+            {
+                Assert.That.FileExists(Path.Combine(runtimeDir, directory));
+            }
+        }
+    }
+}

--- a/tests/Acoustics.Test/TestHelpers/PathHelper.cs
+++ b/tests/Acoustics.Test/TestHelpers/PathHelper.cs
@@ -17,7 +17,10 @@ namespace Acoustics.Test.TestHelpers
             CodeBase = Environment.CurrentDirectory;
             TestResources = Path.Combine(CodeBase, "..", "..", "..", "Fixtures");
             SolutionRoot = Path.Combine(CodeBase, "..", "..", "..", "..");
+            AnalysisProgramsBuild = Path.Combine(SolutionRoot, "src", "AnalysisPrograms", "bin", "debug");
         }
+
+        public static string AnalysisProgramsBuild { get; set; }
 
         public static string SolutionRoot { get; }
 

--- a/tests/Acoustics.Test/packages.config
+++ b/tests/Acoustics.Test/packages.config
@@ -16,8 +16,8 @@
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net462" />
-  <package id="MSTest.TestAdapter" version="1.3.0-beta2" targetFramework="net462" />
-  <package id="MSTest.TestFramework" version="1.3.0-beta2" targetFramework="net462" />
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net462" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net462" />
   <package id="MSTestExtensions" version="4.0.0" targetFramework="net462" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />


### PR DESCRIPTION
Fixes #165

Also updates the version of MSTest we are using.

@peichins can I get you to download the AppVeyor asset from the build and see if it works on your Mac/Mono instance? Thanks