### PR TITLE
DrawRgbColourMatrix now renders gray for cells with NaN values

### DIFF
--- a/src/Acoustics.Shared/Extensions/DoubleExtensions.cs
+++ b/src/Acoustics.Shared/Extensions/DoubleExtensions.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DoubleExtensions.cs" company="QutEcoacoustics">
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
@@ -11,34 +11,28 @@
 namespace System
 {
     using System;
+    using System.Runtime.CompilerServices;
 
     public static class DoubleExtensions
     {
-        public static TimeSpan Seconds(this double seconds)
-        {
-            return TimeSpan.FromSeconds(seconds);
-        }
+        public static TimeSpan Seconds(this double seconds) => TimeSpan.FromSeconds(seconds);
 
-        public static TimeSpan Seconds(this int seconds)
-        {
-            return TimeSpan.FromSeconds(seconds);
-        }
+        public static TimeSpan Seconds(this int seconds) => TimeSpan.FromSeconds(seconds);
 
-        public static TimeSpan Seconds(this long seconds)
-        {
-            return TimeSpan.FromSeconds(seconds);
-        }
+        public static TimeSpan Seconds(this long seconds) => TimeSpan.FromSeconds(seconds);
 
         /// <summary>
-        /// Round a number to `digits` significant places.
-        /// Sourced from: http://stackoverflow.com/questions/374316/round-a-double-to-x-significant-figures
+        /// Round a number to <paramref name="digits"/> significant places.
         /// </summary>
-        /// <param name="d"></param>
-        /// <param name="digits"></param>
-        /// <returns></returns>
-        public static double RoundToSignficantDigits(this double d, int digits)
+        /// <remarks>
+        /// Sourced from: http://stackoverflow.com/questions/374316/round-a-double-to-x-significant-figures.
+        /// </remarks>
+        /// <param name="d">The value to round.</param>
+        /// <param name="digits">The number of significant digits to keep.</param>
+        /// <returns>The rounded value.</returns>
+        public static double RoundToSignificantDigits(this double d, int digits)
         {
-            // preserve value as much as possible - this is reasonable since we will rescale to orginal magnitude
+            // preserve value as much as possible - this is reasonable since we will rescale to original magnitude
             decimal dec = (decimal)d;
             if (dec == 0)
             {
@@ -49,6 +43,50 @@ namespace System
             return (double)(scale * Math.Round(dec / scale, digits, MidpointRounding.AwayFromZero));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Round(this double d, MidpointRounding rounding = MidpointRounding.AwayFromZero) => Math.Round(d, rounding);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Floor(this double d) => Math.Floor(d);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Clamp(this double value, double min, double max)
+        {
+            if (value > max)
+            {
+                return max;
+            }
+
+            if (value < min)
+            {
+                return min;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Scales a unit double value, that is in the interval [0.0, 1.0] to a byte [0, 255]
+        /// value between 0 and 255, clamping out of bound values and rounding away from zero.
+        /// </summary>
+        /// <param name="value">The value</param>
+        /// <returns>The clamped and rounded value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte ScaleUnitToByte(this double value)
+        {
+            value *= byte.MaxValue;
+
+            if (value > byte.MaxValue)
+            {
+                return byte.MaxValue;
+            }
+
+            if (value < byte.MinValue)
+            {
+                return byte.MinValue;
+            }
+
+            return (byte)value.Round();
+        }
     }
 }

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -1187,43 +1187,43 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             {
                 for (int column = 0; column < cols; column++)
                 {
-                    var d1 = redM[row, column];
-                    var d2 = grnM[row, column];
-                    var d3 = bluM[row, column];
+                    var r = redM[row, column];
+                    var g = grnM[row, column];
+                    var b = bluM[row, column];
 
                     // if any of the indices is blank/NaN then render as grey.
-                    if (double.IsNaN(d1) || double.IsNaN(d2) || double.IsNaN(d3))
+                    if (double.IsNaN(r) || double.IsNaN(g) || double.IsNaN(b))
                     {
-                        d1 = 0.5;
-                        d2 = 0.5;
-                        d3 = 0.5;
+                        r = 0.5;
+                        g = 0.5;
+                        b = 0.5;
                     }
 
-                    // enhance blue colour - it is difficult to see on a black background
+                    // enhance blue color - it is difficult to see on a black background
                     // This is a hack - there should be a principled way to do this!
                     // The effect is to create a more visible cyan colour.
-                    if (d1 < 0.1 && d2 < 0.1 && d3 > 0.1)
+                    if (r < 0.1 && g < 0.1 && b > 0.1)
                     {
-                        d2 += 0.7 * d3;
-                        d3 += 0.2;
+                        g += 0.7 * b;
+                        b += 0.2;
 
                         // check for values over 1.0
-                        d2 = Math.Min(1.0, d2);
-                        d3 = Math.Min(1.0, d3);
+                        g = Math.Min(1.0, g);
+                        b = Math.Min(1.0, b);
                     }
 
                     if (doReverseColour)
                     {
-                        d1 = 1 - d1;
-                        d2 = 1 - d2;
-                        d3 = 1 - d3;
+                        r = 1 - r;
+                        g = 1 - g;
+                        b = 1 - b;
                     }
 
-                    var v1 = Convert.ToInt32(Math.Max(0, d1 * maxRgbValue));
-                    var v2 = Convert.ToInt32(Math.Max(0, d2 * maxRgbValue));
-                    var v3 = Convert.ToInt32(Math.Max(0, d3 * maxRgbValue));
-                    var colour = Color.FromArgb(v1, v2, v3);
-                    bmp.SetPixel(column, row, colour);
+                    var v1 = r.ScaleUnitToByte();
+                    var v2 = g.ScaleUnitToByte();
+                    var v3 = b.ScaleUnitToByte();
+                    var color = Color.FromArgb(v1, v2, v3);
+                    bmp.SetPixel(column, row, color);
                 } //end all columns
             }
 

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -311,7 +311,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
 
         /// <summary>
         /// This method sets default indices to use if passed Dictionary = null.
-        /// This may not be a good idea. Trying it out. Maybe better to crash!
+        /// This may not be a good idea. Trying it out. Maybe better to crash!.
         /// </summary>
         public void SetSpectralIndexProperties(Dictionary<string, IndexProperties> dictionaryOfSpectralIndexProperties)
         {
@@ -552,7 +552,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// </summary>
         public Image DrawGreyscaleSpectrogramOfIndex(string key)
         {
-            double[,] matrix = this.GetNormalisedSpectrogramMatrix(key);
+            var matrix = this.GetNormalisedSpectrogramMatrix(key);
             if (matrix == null)
             {
                 return null;
@@ -1081,7 +1081,8 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             {
                 // draw extra time scale with absolute start time. AND THEN Do SOMETHING WITH IT.
                 timeBmp2 = ImageTrack.DrawTimeTrack(fullDuration, cs.RecordingStartDate, bmp1.Width, trackHeight);
-                suntrack = SunAndMoon.AddSunTrackToImage(bmp1.Width, dateTimeOffset, cs.SunriseDataFile);
+
+                //suntrack = SunAndMoon.AddSunTrackToImage(bmp1.Width, dateTimeOffset, cs.SunriseDataFile);
             }
 
             if (cs.FreqScale == null)
@@ -1096,10 +1097,10 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
 
             // draw the composite bitmap
             var imageList = new List<Image> { titleBar, timeBmp1, bmp1, timeBmp2 };
-            if (suntrack != null)
-            {
-                imageList.Add(suntrack);
-            }
+            //if (suntrack != null)
+            //{
+            //    imageList.Add(suntrack);
+            //}
 
             var compositeBmp = (Bitmap)ImageTools.CombineImagesVertically(imageList);
             return compositeBmp;
@@ -1166,9 +1167,15 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             return bmp;
         }
 
+        /// <summary>
+        /// This method assumes that all the passed matrices are normalised and of the same dimensions.
+        /// The method implements a hack to enhance the blue colour because the human eye is less sensitive to blue.
+        /// If there is a problem with one or more of the three rgb values, a gray pixel is substituted not a black pixel.
+        /// Black is a frequent colour in LDFC spectrograms, but gray is highly unlikely,
+        /// and therefore its presence stands out as indicating an error in one or more of the rgb values.
+        /// </summary>
         public static Image DrawRgbColourMatrix(double[,] redM, double[,] grnM, double[,] bluM, bool doReverseColour)
         {
-            // assume all matricies are normalised and of the same dimensions
             int rows = redM.GetLength(0); //number of rows
             int cols = redM.GetLength(1); //number
 
@@ -1184,28 +1191,23 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     var d2 = grnM[row, column];
                     var d3 = bluM[row, column];
 
-                    // blank indices painted grey.
-                    if (double.IsNaN(d1))
+                    // if any of the indices is blank/NaN then render as grey.
+                    if (double.IsNaN(d1) || double.IsNaN(d2) || double.IsNaN(d3))
                     {
                         d1 = 0.5;
-                    }
-
-                    if (double.IsNaN(d2))
-                    {
                         d2 = 0.5;
-                    }
-
-                    if (double.IsNaN(d3))
-                    {
                         d3 = 0.5;
                     }
 
                     // enhance blue colour - it is difficult to see on a black background
-                    // This is a hack - there should be a principled way to do this.
-                    if (d1 < 0.1 && d2 < 0.1 && d3 > 0.2)
+                    // This is a hack - there should be a principled way to do this!
+                    // The effect is to create a more visible cyan colour.
+                    if (d1 < 0.1 && d2 < 0.1 && d3 > 0.1)
                     {
                         d2 += 0.7 * d3;
                         d3 += 0.2;
+
+                        // check for values over 1.0
                         d2 = Math.Min(1.0, d2);
                         d3 = Math.Min(1.0, d3);
                     }
@@ -1407,7 +1409,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             cs1.SiteName = siteDescription?.SiteName;
             cs1.Latitude = siteDescription?.Latitude;
             cs1.Longitude = siteDescription?.Longitude;
-            cs1.SunriseDataFile = sunriseDataFile;
+            //cs1.SunriseDataFile = sunriseDataFile;
             cs1.ErroneousSegments = segmentErrors;
 
             // calculate start time by combining DatetimeOffset with minute offset.

--- a/tests/Acoustics.Test/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGBTests.cs
+++ b/tests/Acoustics.Test/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGBTests.cs
@@ -70,5 +70,41 @@ namespace Acoustics.Test.AudioAnalysisTools.LongDurationSpectrograms
                 Assert.That.ImageRegionIsColor(Rectangle.FromLTRB(0, 0, 60, 256), Color.Black, (Bitmap)image);
             }
         }
+
+        [TestMethod]
+        public void TestDrawRgbColourMatrix()
+        {
+            // init three matrices
+            double[,] redM = new double[5, 5];
+            double[,] grnM = new double[5, 5];
+            double[,] bluM = new double[5, 5];
+
+            //convert some values to null or NaN
+            redM[1, 1] = double.NaN;
+            grnM[1, 1] = double.NaN;
+            bluM[1, 1] = double.NaN;
+
+            redM[2, 2] = 1.0;
+            grnM[2, 2] = 1.0;
+            bluM[2, 2] = double.NaN;
+
+            redM[3, 3] = 0.01;
+            grnM[3, 3] = 0.01;
+            bluM[3, 3] = 0.11;
+
+            var image = (Bitmap)LDSpectrogramRGB.DrawRgbColourMatrix(redM, grnM, bluM, true);
+
+            Assert.That.PixelIsColor(new Point(1, 1), Color.DarkGray, image);
+            Assert.That.PixelIsColor(new Point(2, 2), Color.DarkGray, image);
+
+            // To intensify the blue, this method adds 0.7 * d3 to the green value;
+            // and it adds 0.2 to the blue value;
+            // The effect is to create a more visible cyan colour.
+            int r = (int)(redM[3, 3] * 255);
+            int g = (int)((grnM[3, 3] * 255) + (0.7 * bluM[3, 3]));
+            int b = (int)((bluM[3, 3] + 0.2) * 255);
+            var cyanColour = Color.FromArgb(r, g, b);
+            Assert.That.PixelIsColor(new Point(3, 3), cyanColour, image);
+        }
     }
 }

--- a/tests/Acoustics.Test/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGBTests.cs
+++ b/tests/Acoustics.Test/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGBTests.cs
@@ -72,7 +72,7 @@ namespace Acoustics.Test.AudioAnalysisTools.LongDurationSpectrograms
         }
 
         [TestMethod]
-        public void TestDrawRgbColourMatrix()
+        public void TestDrawRgbColorMatrix()
         {
             // init three matrices
             double[,] redM = new double[5, 5];
@@ -92,19 +92,23 @@ namespace Acoustics.Test.AudioAnalysisTools.LongDurationSpectrograms
             grnM[3, 3] = 0.01;
             bluM[3, 3] = 0.11;
 
-            var image = (Bitmap)LDSpectrogramRGB.DrawRgbColourMatrix(redM, grnM, bluM, true);
+            var image = (Bitmap)LDSpectrogramRGB.DrawRgbColourMatrix(redM, grnM, bluM, doReverseColour: true);
 
-            Assert.That.PixelIsColor(new Point(1, 1), Color.DarkGray, image);
-            Assert.That.PixelIsColor(new Point(2, 2), Color.DarkGray, image);
+            Assert.That.PixelIsColor(new Point(1, 1), Color.FromArgb(128, 128, 128), image);
+            Assert.That.PixelIsColor(new Point(2, 2), Color.FromArgb(128, 128, 128), image);
+
+            // empty values are rendered as white because of `doReverseColour`
+            Assert.That.ImageRegionIsColor(Rectangle.FromLTRB(0,0, 1,5), Color.FromArgb(255, 255, 255), image);
+            Assert.That.ImageRegionIsColor(Rectangle.FromLTRB(4,0, 5,5), Color.FromArgb(255, 255, 255), image);
 
             // To intensify the blue, this method adds 0.7 * d3 to the green value;
             // and it adds 0.2 to the blue value;
-            // The effect is to create a more visible cyan colour.
-            int r = (int)(redM[3, 3] * 255);
-            int g = (int)((grnM[3, 3] * 255) + (0.7 * bluM[3, 3]));
-            int b = (int)((bluM[3, 3] + 0.2) * 255);
-            var cyanColour = Color.FromArgb(r, g, b);
-            Assert.That.PixelIsColor(new Point(3, 3), cyanColour, image);
+            // The effect is to create a more visible cyan color.
+            int r = (1 - redM[3, 3]).ScaleUnitToByte();
+            int g = (1 - (grnM[3, 3] + (0.7 * bluM[3, 3]))).ScaleUnitToByte();
+            int b = (1 - (bluM[3, 3] + 0.2)).ScaleUnitToByte();
+            var cyanColor = Color.FromArgb(r, g, b);
+            Assert.That.PixelIsColor(new Point(3, 3), cyanColor, image);
         }
     }
 }

--- a/tests/Acoustics.Test/TestHelpers/TestHelper.cs
+++ b/tests/Acoustics.Test/TestHelpers/TestHelper.cs
@@ -510,8 +510,8 @@
             if (expected.BitsPerSecond.HasValue && actual.BitsPerSecond.HasValue)
             {
                 // Sox only reports three decimal places and rounds other things
-                var actualBps = (int)((double)actual.BitsPerSecond.Value).RoundToSignficantDigits(3);
-                var expectedBps = (int)((double)expected.BitsPerSecond.Value).RoundToSignficantDigits(3);
+                var actualBps = (int)((double)actual.BitsPerSecond.Value).RoundToSignificantDigits(3);
+                var expectedBps = (int)((double)expected.BitsPerSecond.Value).RoundToSignificantDigits(3);
                 Assert.AreEqual(expectedBps, actualBps, 0);
             }
 


### PR DESCRIPTION
Fix faulty logic when drawing LDFC colour matrices. However note that errors are shown in gray because this is a most unlikely colour in LDFC spectrograms.

Closes #154 