### PR TITLE
Adds rendering of ALL grayscale LD spectrograms to standard indices generation

### DIFF
--- a/src/AnalysisConfigFiles/IndexPropertiesConfig.yml
+++ b/src/AnalysisConfigFiles/IndexPropertiesConfig.yml
@@ -650,8 +650,8 @@ OSC:
   DataType: double[]
   DefaultValue: 0.0
   DoDisplay: true
-  NormMin: 0.0
-  NormMax: 10.0
+  NormMin: 0.1
+  NormMax: 5.0
   CalculateNormMin: true
   CalculateNormMax: true
   ProjectID: Acoustic Indices
@@ -687,7 +687,7 @@ RHZ:
   DefaultValue: 0.0
   DoDisplay: true
   NormMin: 0.1
-  NormMax: 1.5
+  NormMax: 1.0
   CalculateNormMin: false
   CalculateNormMax: false
   ProjectID: Acoustic Indices
@@ -700,8 +700,8 @@ RVT:
   DoDisplay: true
   NormMin: 0.1
   NormMax: 0.4
-  CalculateNormMin: false
-  CalculateNormMax: false
+  CalculateNormMin: true
+  CalculateNormMax: true
   ProjectID: Acoustic Indices
   Units: "tracks/s"
 RPS:
@@ -712,8 +712,8 @@ RPS:
   DoDisplay: true
   NormMin: 0.0
   NormMax: 0.4
-  CalculateNormMin: false
-  CalculateNormMax: false
+  CalculateNormMin: true
+  CalculateNormMax: true
   ProjectID: Acoustic Indices
   Units: "tracks/s"
 RNG:
@@ -724,8 +724,8 @@ RNG:
   DoDisplay: true
   NormMin: 0.0
   NormMax: 0.4
-  CalculateNormMin: false
-  CalculateNormMax: false
+  CalculateNormMin: true
+  CalculateNormMax: true
   ProjectID: Acoustic Indices
   Units: "tracks/s"
 R3D:
@@ -736,8 +736,8 @@ R3D:
   DoDisplay: true
   NormMin: 0.15
   NormMax: 1.0
-  CalculateNormMin: false
-  CalculateNormMax: false
+  CalculateNormMin: true
+  CalculateNormMax: true
   ProjectID: Acoustic Indices
   Units: "tracks/s"
 SPT:

--- a/src/AnalysisConfigFiles/IndexPropertiesConfig.yml
+++ b/src/AnalysisConfigFiles/IndexPropertiesConfig.yml
@@ -613,7 +613,7 @@ DIF:
   Comment: "Spectrum of summed DIFFERENCES between consecutive FFT coeff's in the ampl spgram. This spgram not displayed. It is used as intermediate for subsequent calculation of ACI."
   DataType: double[]
   DefaultValue: 0.0
-  DoDisplay: true
+  DoDisplay: false
   NormMin: 0.0
   NormMax: 10.0
   CalculateNormMin: false
@@ -661,7 +661,7 @@ SUM:
   Comment: "Spectrum of summed FFT coefficients derived from the ampl spgram. This spgram not displayed. It is used for intermediate calculations only."
   DataType: double[]
   DefaultValue: 0.0
-  DoDisplay: true
+  DoDisplay: false
   NormMin: 0.0
   NormMax: 10.0
   CalculateNormMin: false

--- a/src/AnalysisPrograms/Sandpit.cs
+++ b/src/AnalysisPrograms/Sandpit.cs
@@ -6,7 +6,6 @@ namespace AnalysisPrograms
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Drawing;
     using System.Drawing.Imaging;
     using System.Globalization;
@@ -16,17 +15,15 @@ namespace AnalysisPrograms
     using System.Threading.Tasks;
     using Acoustics.Shared;
     using Acoustics.Shared.Csv;
-    using AnalyseLongRecordings;
+    using AnalysisPrograms.AnalyseLongRecordings;
     using AudioAnalysisTools;
     using AudioAnalysisTools.DSP;
     using AudioAnalysisTools.Indices;
     using AudioAnalysisTools.LongDurationSpectrograms;
     using AudioAnalysisTools.StandardSpectrograms;
     using AudioAnalysisTools.WavTools;
-    using log4net.Util;
     using McMaster.Extensions.CommandLineUtils;
-    using Production;
-    using Production.Arguments;
+    using AnalysisPrograms.Production.Arguments;
     using TowseyLibrary;
 
     /// <summary>
@@ -64,7 +61,7 @@ namespace AnalysisPrograms
                 Log.WriteLine("# Start Time = " + tStart.ToString(CultureInfo.InvariantCulture));
 
                 //AnalyseFrogDataSet();
-                //Audio2CsvOverOneFile();
+                Audio2CsvOverOneFile();
                 //Audio2CsvOverMultipleFiles();
 
                 // used to get files from availae for Black rail and Least Bittern papers.
@@ -103,8 +100,8 @@ namespace AnalysisPrograms
                 //TestTernaryPlots();
                 //TestDirectorySearchAndFileSearch();
                 //TestNoiseReduction();
-                Oscillations2014.TESTMETHOD_DrawOscillationSpectrogram();
-                Oscillations2014.TESTMETHOD_GetSpectralIndex_Osc();
+                //Oscillations2014.TESTMETHOD_DrawOscillationSpectrogram();
+                //Oscillations2014.TESTMETHOD_GetSpectralIndex_Osc();
                 //Test_DrawFourSpectrograms();
 
                 Console.WriteLine("# Finished Sandpit Task!    Press any key to exit.");
@@ -323,6 +320,10 @@ namespace AnalysisPrograms
             //string outputPath = @"G:\SensorNetworks\Output\BradLaw\Pillaga24";
             //string configPath = @"C:\Work\GitHub\audio-analysis\AudioAnalysis\AnalysisConfigFiles\Towsey.Acoustic.yml";
 
+            string recordingPath = @"C:\Ecoacoustics\WavFiles\LizZnidersic\TasmanIsland2015_Unit2_Mez\SM304256_0+1_20151114_001652.wav";
+            string outputPath = @"C:\Ecoacoustics\Output\Test\Test24HourRecording\TasmanIslandMez\01";
+            string configPath = @"C:\Work\GitHub\audio-analysis\src\AnalysisConfigFiles\Towsey.Acoustic.yml";
+
             // Ivan Campos recordings
             //string recordingPath = @"G:\SensorNetworks\WavFiles\Ivancampos\INCIPO01_20161031_024006_898.wav";
             //string outputPath = @"G:\SensorNetworks\Output\IvanCampos\17";
@@ -380,9 +381,9 @@ namespace AnalysisPrograms
 
             // SERF RECORDINGS FROM 19th June 2013
             // these are six hour recordings
-            string recordingPath = @"G:\Ecoacoustics\WavFiles\SERF\2013June19\SERF_20130619_064615_000.wav";
-            string outputPath = @"C:\Ecoacoustics\Output\SERF\SERFIndicesNew_2013June19";
-            string configPath = @"C:\Work\GitHub\audio-analysis\src\AnalysisConfigFiles\Towsey.Acoustic.yml";
+            //string recordingPath = @"G:\Ecoacoustics\WavFiles\SERF\2013June19\SERF_20130619_064615_000.wav";
+            //string outputPath = @"C:\Ecoacoustics\Output\SERF\SERFIndicesNew_2013June19";
+            //string configPath = @"C:\Work\GitHub\audio-analysis\src\AnalysisConfigFiles\Towsey.Acoustic.yml";
 
             // GROUND PARROT
             //string recordingPath = @"C:\SensorNetworks\WavFiles\TestRecordings\groundParrot_Perigian_TEST.wav";

--- a/src/AnalysisPrograms/Sandpit.cs
+++ b/src/AnalysisPrograms/Sandpit.cs
@@ -61,7 +61,7 @@ namespace AnalysisPrograms
                 Log.WriteLine("# Start Time = " + tStart.ToString(CultureInfo.InvariantCulture));
 
                 //AnalyseFrogDataSet();
-                Audio2CsvOverOneFile();
+                //Audio2CsvOverOneFile();
                 //Audio2CsvOverMultipleFiles();
 
                 // used to get files from availae for Black rail and Least Bittern papers.
@@ -71,6 +71,7 @@ namespace AnalysisPrograms
                 //CodeToPlaceScoreTracksUnderSingleImage();
 
                 //ConcatenateIndexFilesAndSpectrograms();
+                ConcatenateGreyScaleSpectrogramImages();
                 //ConcatenateMarineImages();
                 //ConcatenateImages();
                 //ConcatenateTwelveImages();
@@ -1051,11 +1052,60 @@ namespace AnalysisPrograms
         }
 
         /// <summary>
-        /// read a set of Spectral index files and extract values from frequency band
-        /// This work done for Liz Znidersic paper.
-        /// End of the method requires access to Liz tagging info.
+        /// TODO Combine the grey scale spectrograms produced by AnalysisPrograms.exe
+        /// This method will be useful for comparing the response of different spectral indices to the same acoustic event.
+        /// Use this when you want best acoustic features for doing ML using spectral index features.
         /// </summary>
-        public static void ExtractSpectralFeatures()
+        public static void ConcatenateGreyScaleSpectrogramImages()
+        {
+
+            var ipDirInfo = new DirectoryInfo(@"C:\Ecoacoustics\Output\Test\Test24HourRecording\TasmanIslandMez\01\Towsey.Acoustic");
+            var opDirInfo = new DirectoryInfo(@"C:\Ecoacoustics\Output\Test\Test24HourRecording\TasmanIslandMez\01\Towsey.Acoustic");
+            var opFileName = "SM304256_0+1_20151114_001652";
+
+            //string[] keys = { "ACI", "BGN", "CVR", "ENT", "EVN", "OSC", "PMN", "R3D", "RHZ", "RNG", "RPS", "RVT", "SPT" };
+            var keys = SpectralIndexValues.Keys;
+
+            //Read list of images into List
+            var listOfImages = new List<Image>();
+
+            foreach (var key in keys)
+            {
+                if (key == "DIF" || key == "SUM")
+                {
+                    continue;
+                }
+
+                // construct the path
+                //var path = Path.Combine(ipDirInfo.FullName, opFileName + key + ".png");
+                var path = FilenameHelpers.AnalysisResultPath(ipDirInfo, opFileName, key, "png");
+                var indexImage = ImageTools.ReadImage2Bitmap(path);
+
+                listOfImages.Add(indexImage);
+            }
+
+            var opPath = FilenameHelpers.AnalysisResultPath(opDirInfo, opFileName, "KEYS", "png");
+
+            // check how wide combined image will be. If tracks are wider than 180 = 3 hours, then go vertical
+            int imageCount = listOfImages.Count;
+            if (listOfImages[0].Width * imageCount > 180 * imageCount)
+            {
+                var combinedImage = ImageTools.CombineImagesVertically(listOfImages);
+                combinedImage?.Save(opPath);
+            }
+            else
+            {
+                var combinedImage = ImageTools.CombineImagesInLine(listOfImages);
+                combinedImage?.Save(opPath);
+            }
+        }
+
+    /// <summary>
+    /// read a set of Spectral index files and extract values from frequency band
+    /// This work done for Liz Znidersic paper.
+    /// End of the method requires access to Liz tagging info.
+    /// </summary>
+    public static void ExtractSpectralFeatures()
         {
             // parameters
             string dir =

--- a/src/AudioAnalysisTools/DSP/FrequencyScale.cs
+++ b/src/AudioAnalysisTools/DSP/FrequencyScale.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FrequencyScale.cs" company="QutEcoacoustics">
+// <copyright file="FrequencyScale.cs" company="QutEcoacoustics">
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
 
@@ -396,9 +396,16 @@ namespace AudioAnalysisTools.DSP
             for (int b = 0; b < bandCount; b++)
             {
                 int y = height - gridLineLocations[b, 0];
+                int hertzValue = gridLineLocations[b, 1];
+                if (bmp.Width < 120)
+                {
+                    // convert label to kHz so does not hide too much spectrogram
+                    hertzValue = hertzValue / 1000;
+                }
+
                 if (y > 1)
                 {
-                    g.DrawString($"{gridLineLocations[b, 1]}", new Font("Thachoma", 8), txtColour, 1, y);
+                    g.DrawString($"{hertzValue}", new Font("Thachoma", 8), txtColour, 1, y);
                 }
             }
         } //end AddHzGridLines()

--- a/src/AudioAnalysisTools/DSP/FrequencyScale.cs
+++ b/src/AudioAnalysisTools/DSP/FrequencyScale.cs
@@ -397,11 +397,6 @@ namespace AudioAnalysisTools.DSP
             {
                 int y = height - gridLineLocations[b, 0];
                 int hertzValue = gridLineLocations[b, 1];
-                if (bmp.Width < 120)
-                {
-                    // convert label to kHz so does not hide too much spectrogram
-                    hertzValue = hertzValue / 1000;
-                }
 
                 if (y > 1)
                 {

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -495,6 +495,15 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                         maxBound = this.IndexStats[key].Maximum * 0.1;
                     }
                 }
+
+                // In some rare cases the resulting range is zero which will produce NaNs when normalized.
+                // In this case we just reset the bounds backs to the defaults in the config file.
+                // ReSharper disable once CompareOfFloatsByEqualityOperator - we are interested in ranges that are exactly zero distance
+                if (maxBound == minBound)
+                {
+                    minBound = indexProperties.NormMin;
+                    maxBound = indexProperties.NormMax;
+                }
             }
 
             // check min, max values

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -36,6 +36,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Drawing;
+    using System.Drawing.Drawing2D;
     using System.Drawing.Imaging;
     using System.Globalization;
     using System.IO;
@@ -476,6 +477,12 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     {
                         minBound = indexProperties.NormMin;
                     }
+
+                    // Do not want OSC min set too low. Happens because min can = zero
+                    if (key.Equals("OSC") && minBound < indexProperties.NormMin)
+                    {
+                        minBound = indexProperties.NormMin;
+                    }
                 }
 
                 if (indexProperties.CalculateNormMax)
@@ -500,22 +507,20 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         }
 
         /// <summary>
-        /// Draws all available spectrograms in grey scale
-        /// </summary>
-        public void DrawGreyScaleSpectrograms(DirectoryInfo opdir, string opFileName)
-        {
-            var keys = SpectralIndexValues.Keys;
-            //string[] keys = this.SpectrogramKeys;
-            this.DrawGreyScaleSpectrograms(opdir, opFileName, keys);
-        }
-
-        /// <summary>
         /// draws only those spectrograms in the passed array of keys
         /// </summary>
         public void DrawGreyScaleSpectrograms(DirectoryInfo opdir, string opFileName, string[] keys)
         {
+            // init List of track images
+            var listOfImages = new List<Image>();
+
             foreach (string key in keys)
             {
+                if (key == "SUM" || key == "DIF")
+                {
+                    continue;
+                }
+
                 if (!this.SpectrogramMatrices.ContainsKey(key))
                 {
                     LoggedConsole.WriteErrorLine("\n\nWARNING: From method LDSpectrogram.DrawGreyScaleSpectrograms()");
@@ -540,10 +545,38 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     continue;
                 }
 
-                // the directory for the following path must exist
-                var path = FilenameHelpers.AnalysisResultPath(opdir, opFileName, key, "png");
                 var bmp = this.DrawGreyscaleSpectrogramOfIndex(key);
-                bmp?.Save(path);
+
+                var header = new Bitmap(bmp.Width, 20);
+                Graphics g = Graphics.FromImage(header);
+                g.Clear(Color.LightGray);
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+                //g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                //g.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                g.DrawString(key, new Font("Tahoma", 9), Brushes.Black, 4, 4);
+                var indexImage = ImageTools.CombineImagesVertically(new List<Image>(new Image[] { header, bmp }));
+
+                // save the image - the directory for the path must exist
+                //var path = FilenameHelpers.AnalysisResultPath(opdir, opFileName, key, "png");
+                //indexImage?.Save(path);
+
+                listOfImages.Add(indexImage);
+            }
+
+            // save the combined track image - the directory for the path must exist
+            var path = FilenameHelpers.AnalysisResultPath(opdir, opFileName, "KEYS", "png");
+            int imageCount = listOfImages.Count;
+
+            // check how wide combined image will be. If tracks are wider than 180 = 3 hours, then go vertical
+            if (listOfImages[0].Width * imageCount > 180 * imageCount)
+            {
+                var combinedImage = ImageTools.CombineImagesVertically(listOfImages);
+                combinedImage?.Save(path);
+            }
+            else
+            {
+                var combinedImage = ImageTools.CombineImagesInLine(listOfImages);
+                combinedImage?.Save(path);
             }
         }
 
@@ -1473,10 +1506,18 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             cs1.IndexStats = indexStatistics;
 
             // draw gray scale spectrogram for each index.
-            string[] keys = colorMap1.Split('-');
+            //string[] keys = colorMap1.Split('-');
+            //cs1.DrawGreyScaleSpectrograms(outputDirectory, fileStem, keys);
+            //keys = colorMap2.Split('-');
+            // draw all available gray scale index spectrograms.
+            var keys = SpectralIndexValues.Keys;
             cs1.DrawGreyScaleSpectrograms(outputDirectory, fileStem, keys);
-            keys = colorMap2.Split('-');
-            cs1.DrawGreyScaleSpectrograms(outputDirectory, fileStem, keys);
+
+            //    //string[] keys = this.SpectrogramKeys;
+            //cs1.DrawGreyScaleSpectrograms(outputDirectory, fileStem, keys);
+            //}
+            //keys = colorMap2.Split('-');
+            //cs1.DrawGreyScaleSpectrograms(outputDirectory, fileStem, keys);
 
             // create and save first false-colour spectrogram image
             var image1NoChrome = cs1.DrawFalseColourSpectrogramChromeless(cs1.ColorMode, colorMap1);

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -511,16 +511,8 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// </summary>
         public void DrawGreyScaleSpectrograms(DirectoryInfo opdir, string opFileName, string[] keys)
         {
-            // init List of track images
-            var listOfImages = new List<Image>();
-
             foreach (string key in keys)
             {
-                if (key == "SUM" || key == "DIF")
-                {
-                    continue;
-                }
-
                 if (!this.SpectrogramMatrices.ContainsKey(key))
                 {
                     LoggedConsole.WriteErrorLine("\n\nWARNING: From method LDSpectrogram.DrawGreyScaleSpectrograms()");
@@ -545,6 +537,12 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     continue;
                 }
 
+                var ipList = this.GetSpectralIndexProperties();
+                if (!ipList[key].DoDisplay)
+                {
+                    continue;
+                }
+
                 var bmp = this.DrawGreyscaleSpectrogramOfIndex(key);
 
                 var header = new Bitmap(bmp.Width, 20);
@@ -557,32 +555,13 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                 var indexImage = ImageTools.CombineImagesVertically(new List<Image>(new Image[] { header, bmp }));
 
                 // save the image - the directory for the path must exist
-                //var path = FilenameHelpers.AnalysisResultPath(opdir, opFileName, key, "png");
-                //indexImage?.Save(path);
-
-                listOfImages.Add(indexImage);
-            }
-
-            // save the combined track image - the directory for the path must exist
-            var path = FilenameHelpers.AnalysisResultPath(opdir, opFileName, "KEYS", "png");
-            int imageCount = listOfImages.Count;
-
-            // check how wide combined image will be. If tracks are wider than 180 = 3 hours, then go vertical
-            if (listOfImages[0].Width * imageCount > 180 * imageCount)
-            {
-                var combinedImage = ImageTools.CombineImagesVertically(listOfImages);
-                combinedImage?.Save(path);
-            }
-            else
-            {
-                var combinedImage = ImageTools.CombineImagesInLine(listOfImages);
-                combinedImage?.Save(path);
+                var path = FilenameHelpers.AnalysisResultPath(opdir, opFileName, key, "png");
+                indexImage?.Save(path);
             }
         }
 
         /// <summary>
-        /// Assume calling method has done all the reality checks
-        /// </summary>
+        /// Assume calling method has done all the reality checks </summary>
         public Image DrawGreyscaleSpectrogramOfIndex(string key)
         {
             double[,] matrix = this.GetNormalisedSpectrogramMatrix(key);

--- a/tests/Acoustics.Test/AnalysisPrograms/AnalyzeLongRecordings/TestAnalyzeLongRecording.cs
+++ b/tests/Acoustics.Test/AnalysisPrograms/AnalyzeLongRecordings/TestAnalyzeLongRecording.cs
@@ -98,7 +98,7 @@ namespace Acoustics.Test.AnalysisPrograms.AnalyzeLongRecordings
             var resultsDirectory = this.outputDirectory.Combine("Towsey.Acoustic");
             var listOfFiles = resultsDirectory.EnumerateFiles().ToArray();
 
-            Assert.AreEqual(31, listOfFiles.Length);
+            Assert.AreEqual(38, listOfFiles.Length);
 
             var csvCount = listOfFiles.Count(f => f.Name.EndsWith(".csv"));
             Assert.AreEqual(16, csvCount);
@@ -107,7 +107,7 @@ namespace Acoustics.Test.AnalysisPrograms.AnalyzeLongRecordings
             Assert.AreEqual(2, jsonCount);
 
             var pngCount = listOfFiles.Count(f => f.Name.EndsWith(".png"));
-            Assert.AreEqual(13, pngCount);
+            Assert.AreEqual(20, pngCount);
 
             var twoMapsImagePath = resultsDirectory.CombineFile("TemporaryRecording1__2Maps.png");
             var twoMapsImage = ImageTools.ReadImage2Bitmap(twoMapsImagePath.FullName);
@@ -266,10 +266,10 @@ namespace Acoustics.Test.AnalysisPrograms.AnalyzeLongRecordings
                     analysisType: analysisType,
                     indexSpectrograms: dictionaryOfSpectra);
 
-            // test number of images - should now be 14
+            // test number of images - should now be 23
             listOfFiles = resultsDirectory.EnumerateFiles().ToArray();
             pngCount = listOfFiles.Count(f => f.Name.EndsWith(".png"));
-            Assert.AreEqual(14, pngCount);
+            Assert.AreEqual(21, pngCount);
 
             var twoMapsImagePath = resultsDirectory.CombineFile(recordingName + "__2Maps.png");
             var twoMapsImage = ImageTools.ReadImage2Bitmap(twoMapsImagePath.FullName);

--- a/tests/Acoustics.Test/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGBTests.cs
+++ b/tests/Acoustics.Test/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGBTests.cs
@@ -15,12 +15,12 @@ namespace Acoustics.Test.AudioAnalysisTools.LongDurationSpectrograms
     using System.Threading.Tasks;
     using Acoustics.Shared;
     using Acoustics.Shared.ConfigFile;
+    using Acoustics.Test.TestHelpers;
     using global::AnalysisBase.ResultBases;
     using global::AnalysisPrograms;
     using global::AudioAnalysisTools.Indices;
     using global::AudioAnalysisTools.LongDurationSpectrograms;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using TestHelpers;
 
     [TestClass]
     public class LDSpectrogramRGBTests : OutputDirectoryTest
@@ -31,13 +31,13 @@ namespace Acoustics.Test.AudioAnalysisTools.LongDurationSpectrograms
             var indexPropertiesFile = ConfigFile.Default<IndexPropertiesCollection>();
             var indexProperties = ConfigFile.Deserialize<IndexPropertiesCollection>(indexPropertiesFile);
 
-            var indexSpecotrgrams = new Dictionary<string, double[,]>(6);
+            var indexSpectrograms = new Dictionary<string, double[,]>(6);
             var indexStatistics = new Dictionary<string, IndexDistributions.SpectralStats>();
             var keys = (LDSpectrogramRGB.DefaultColorMap1 + "-" + LDSpectrogramRGB.DefaultColorMap2).Split('-');
             foreach (var key in keys)
             {
                 var matrix = new double[256, 60].Fill(indexProperties[key].DefaultValue);
-                indexSpecotrgrams.Add(key, matrix);
+                indexSpectrograms.Add(key, matrix);
 
                 indexStatistics.Add(key, IndexDistributions.GetModeAndOneTailedStandardDeviation(matrix, 300, IndexDistributions.UpperPercentileDefault));
             }
@@ -58,15 +58,18 @@ namespace Acoustics.Test.AudioAnalysisTools.LongDurationSpectrograms
                 },
                 basename: "RGB_TEST",
                 analysisType: AcousticIndices.AnalysisName,
-                indexSpectrograms: indexSpecotrgrams,
-                summaryIndices: Enumerable.Range(0, 60)
-                    .Select((x) => new SummaryIndexValues(60.0.Seconds(), indexProperties)).ToArray(),
+                indexSpectrograms: indexSpectrograms,
+                summaryIndices: Enumerable
+                    .Range(0, 60)
+                    .Select((x) => new SummaryIndexValues(60.0.Seconds(), indexProperties))
+                    .Cast<SummaryIndexBase>()
+                    .ToArray(),
                 indexStatistics: indexStatistics,
                 imageChrome: ImageChrome.Without);
 
             foreach (var (image, key) in images)
             {
-                // image.Save(Path.Combine(this.outputDirectory.FullName, key + ".png"), ImageFormat.Png);
+                Assert.That.ImageIsSize(60, 256, image);
                 Assert.That.ImageRegionIsColor(Rectangle.FromLTRB(0, 0, 60, 256), Color.Black, (Bitmap)image);
             }
         }


### PR DESCRIPTION
I have finished with issue #199. I combined the grey scale spectrograms into one image because it is most helpful to be able to compare them side by side. If spectrograms are too wide then they are joined vertically.

![sm304256_0 1_20151114_001652__keys](https://user-images.githubusercontent.com/7237507/51946703-20fd8980-246e-11e9-8e73-b9f62786a191.png)
