### PR TITLE
Implements alternating background colors for summary indices image

### DIFF
--- a/src/AnalysisPrograms/Sandpit.cs
+++ b/src/AnalysisPrograms/Sandpit.cs
@@ -64,7 +64,7 @@ namespace AnalysisPrograms
                 Log.WriteLine("# Start Time = " + tStart.ToString(CultureInfo.InvariantCulture));
 
                 //AnalyseFrogDataSet();
-                //Audio2CsvOverOneFile();
+                Audio2CsvOverOneFile();
                 //Audio2CsvOverMultipleFiles();
 
                 // used to get files from availae for Black rail and Least Bittern papers.
@@ -103,8 +103,8 @@ namespace AnalysisPrograms
                 //TestTernaryPlots();
                 //TestDirectorySearchAndFileSearch();
                 //TestNoiseReduction();
-                Oscillations2014.TESTMETHOD_DrawOscillationSpectrogram();
-                Oscillations2014.TESTMETHOD_GetSpectralIndex_Osc();
+                //Oscillations2014.TESTMETHOD_DrawOscillationSpectrogram();
+                //Oscillations2014.TESTMETHOD_GetSpectralIndex_Osc();
                 //Test_DrawFourSpectrograms();
 
                 Console.WriteLine("# Finished Sandpit Task!    Press any key to exit.");
@@ -380,8 +380,14 @@ namespace AnalysisPrograms
 
             // SERF RECORDINGS FROM 19th June 2013
             // these are six hour recordings
-            string recordingPath = @"G:\Ecoacoustics\WavFiles\SERF\2013June19\SERF_20130619_064615_000.wav";
-            string outputPath = @"C:\Ecoacoustics\Output\SERF\SERFIndicesNew_2013June19";
+            //string recordingPath = @"G:\Ecoacoustics\WavFiles\SERF\2013June19\SERF_20130619_064615_000.wav";
+            //string outputPath = @"C:\Ecoacoustics\Output\SERF\SERFIndicesNew_2013June19";
+            //string configPath = @"C:\Work\GitHub\audio-analysis\src\AnalysisConfigFiles\Towsey.Acoustic.yml";
+
+            // USE 24-hour data or parts of from MEZ, TASMAn ISLAND, liz Znidersic
+            // these are six hour recordings
+            string recordingPath = @"C:\Ecoacoustics\WavFiles\LizZnidersic\TasmanIsland2015_Unit2_Mez\SM304256_0+1_20151114_031652.wav";
+            string outputPath = @"C:\Ecoacoustics\Output\Test\Test24HourRecording\TasmanIslandMez\04";
             string configPath = @"C:\Work\GitHub\audio-analysis\src\AnalysisConfigFiles\Towsey.Acoustic.yml";
 
             // GROUND PARROT

--- a/src/AudioAnalysisTools/Indices/IndexProperties.cs
+++ b/src/AudioAnalysisTools/Indices/IndexProperties.cs
@@ -260,12 +260,14 @@ namespace AudioAnalysisTools.Indices
             return string.Format(" {0} ({1:f2} .. {2:f2} {3})", this.Name, this.NormMin, this.NormMax, this.Units);
         }
 
+        public Image GetPlotImage(double[] array, List<GapsAndJoins> errors = null) => this.GetPlotImage(array, Color.White, errors);
+
         /// <summary>
         /// For writing this method:
         ///    See CLASS: DrawSummaryIndices
         ///       METHOD: Bitmap ConstructVisualIndexImage(DataTable dt, string title, int timeScale, double[] order, bool doNormalise)
         /// </summary>
-        public Image GetPlotImage(double[] array, List<GapsAndJoins> errors = null)
+        public Image GetPlotImage(double[] array, Color backgroundColour, List<GapsAndJoins> errors = null)
         {
             int dataLength = array.Length;
             string annotation = this.GetPlotAnnotation();
@@ -273,11 +275,10 @@ namespace AudioAnalysisTools.Indices
 
             int trackWidth = dataLength + IndexDisplay.TrackEndPanelWidth;
             int trackHeight = IndexDisplay.DefaultTrackHeight;
-            Color[] grayScale = ImageTools.GrayScale();
 
             Bitmap bmp = new Bitmap(trackWidth, trackHeight);
             Graphics g = Graphics.FromImage(bmp);
-            g.Clear(grayScale[240]);
+            g.Clear(backgroundColour);
 
             // for pixels in the line
             for (int i = 0; i < dataLength; i++)
@@ -312,11 +313,8 @@ namespace AudioAnalysisTools.Indices
                 bmp.SetPixel(i, 0, Color.Gray);
             }
 
-            // end over all pixels
-            int endWidth = trackWidth - dataLength;
             var font = new Font("Arial", 9.0f, FontStyle.Regular);
-            g.FillRectangle(Brushes.Black, dataLength + 1, 0, endWidth, trackHeight);
-            g.DrawString(annotation, font, Brushes.White, new PointF(dataLength + 5, 2));
+            g.DrawString(annotation, font, Brushes.Black, new PointF(dataLength, 5));
 
             // now add in image patches for possible erroneous index segments
             if (errors != null && errors.Count > 0)


### PR DESCRIPTION
Summary index tracks now easier to view when they are long. Size of image has not changed, just the background components.
Example attached

![sm304256_0 1_20151114_031652__summaryindices](https://user-images.githubusercontent.com/7237507/52023575-5aef8e00-2549-11e9-9b4f-14fda94411c8.png)

Fixes #212