### PR TITLE
Concat crashes issue #170

### DIFF
--- a/src/AnalysisPrograms/ConcatenateIndexFiles.cs
+++ b/src/AnalysisPrograms/ConcatenateIndexFiles.cs
@@ -356,7 +356,8 @@ namespace AnalysisPrograms
                             dictionaryOfSummaryIndices,
                             imageTitle,
                             indexGenerationData.IndexCalculationDuration,
-                            indexGenerationData.RecordingStartDate);
+                            indexGenerationData.RecordingStartDate,
+                            gapsAndJoins);
 
                     var imagePath = FilenameHelpers.AnalysisResultPath(resultsDir, outputFileStem, "SummaryIndices", "png");
                     tracksImage.Save(imagePath);

--- a/src/AnalysisPrograms/ConcatenateIndexFiles.cs
+++ b/src/AnalysisPrograms/ConcatenateIndexFiles.cs
@@ -339,6 +339,8 @@ namespace AnalysisPrograms
                 var concatenatedSummaryIndices = LdSpectrogramStitching.ConcatenateAllSummaryIndexFiles(summaryIndexFiles, resultsDir, indexGenerationData, outputFileStem);
                 WriteSummaryIndexFile(resultsDir, outputFileStem, AcousticIndices.TowseyAcoustic, concatenatedSummaryIndices);
 
+                // Put SUMMARY indices into dictionary. TODO need to generalise a lower method
+                // ################# WARNING: THIS METHOD ONLY GETS A "HARD CODED" LIST OF SUMMARY INDICES. See the method.
                 var dictionaryOfSummaryIndices = LdSpectrogramStitching.ConvertToDictionaryOfSummaryIndices(concatenatedSummaryIndices);
 
                 // REALITY CHECK - check for continuous zero indices or anything else that might indicate defective signal,
@@ -442,6 +444,8 @@ namespace AnalysisPrograms
                 var concatenatedSummaryIndices = LdSpectrogramStitching.ConcatenateAllSummaryIndexFiles(indexFiles, resultsDir, indexGenerationData, outputBaseName);
                 WriteSummaryIndexFile(resultsDir, outputBaseName, AcousticIndices.TowseyAcoustic, concatenatedSummaryIndices);
 
+                // Put SUMMARY indices into dictionary. TODO need to generalise a lower method
+                // ################# WARNING: THIS METHOD ONLY GETS A "HARD CODED" LIST OF SUMMARY INDICES. See the method.
                 var summaryDict = LdSpectrogramStitching.ConvertToDictionaryOfSummaryIndices(concatenatedSummaryIndices);
 
                 if (summaryDict == null)

--- a/src/AnalysisPrograms/Sandpit.cs
+++ b/src/AnalysisPrograms/Sandpit.cs
@@ -73,7 +73,7 @@ namespace AnalysisPrograms
                 //CodeToPlaceScoreTracksUnderLdfcSpectrograms();
                 //CodeToPlaceScoreTracksUnderSingleImage();
 
-                //ConcatenateIndexFilesAndSpectrograms();
+                ConcatenateIndexFilesAndSpectrograms();
                 //ConcatenateMarineImages();
                 //ConcatenateImages();
                 //ConcatenateTwelveImages();
@@ -103,8 +103,8 @@ namespace AnalysisPrograms
                 //TestTernaryPlots();
                 //TestDirectorySearchAndFileSearch();
                 //TestNoiseReduction();
-                Oscillations2014.TESTMETHOD_DrawOscillationSpectrogram();
-                Oscillations2014.TESTMETHOD_GetSpectralIndex_Osc();
+                //Oscillations2014.TESTMETHOD_DrawOscillationSpectrogram();
+                //Oscillations2014.TESTMETHOD_GetSpectralIndex_Osc();
                 //Test_DrawFourSpectrograms();
 
                 Console.WriteLine("# Finished Sandpit Task!    Press any key to exit.");
@@ -632,7 +632,7 @@ namespace AnalysisPrograms
         }
 
         /// <summary>
-        /// This action item = "concatenateIndexFiles"
+        /// This action item = "concatenateIndexFiles".
         /// </summary>
         public static void ConcatenateIndexFilesAndSpectrograms()
         {
@@ -708,6 +708,7 @@ namespace AnalysisPrograms
 
             // ########################## CONCATENATION of MARINA SCARPELLI recordings from Brazil
             // The drive: work = G; home = E
+            /*
             drive = "C";
 
             // top level directory AVAILAE JOB #
@@ -728,9 +729,33 @@ namespace AnalysisPrograms
             dtoEnd = new DateTimeOffset(2016, 12, 31, 0, 0, 0, TimeSpan.Zero);
 
             // there are three options for rendering of gaps/missing data: NoGaps, TimedGaps and EchoGaps.
+            gapRendering = "TimedGaps";  */
+
+            // ######################### END OF CONCATENATION of MARINA SCARPELLI recordings from Brazil
+
+            // ######################### START OF FIX ISSUE #170 concat crashes
+            // ######################### use data from availae 
+
+            // top level directory AVAILAE JOB #
+            string[] dataDirs =
+            {
+                @"Y:\Results\20180608-103353 - Tshering, Towsey.Indices, #216\Tshering\WBH_Walaytar\WBH_2018\Bermo",
+            };
+
+            string directoryFilter = "WAKLAYTAR_20180321_*.wav"; // this is a directory filter to locate only the required files
+            string opFileStem = "WAKLAYTAR_20180321";
+            string opPath = @"C:\Ecoacoustics\Output\Test\DebugIssue170";
+            var falseColourSpgConfig = $"C:\\Work\\GitHub\\audio-analysis\\src\\AnalysisConfigFiles\\SpectrogramFalseColourConfig.yml";
+            concatenateEverythingYouCanLayYourHandsOn = true;
+
+            // start and end dates INCLUSIVE
+            //dtoStart = new DateTimeOffset(2016, 12, 31, 0, 0, 0, TimeSpan.Zero);
+            //dtoEnd = new DateTimeOffset(2016, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+            // there are three options for rendering of gaps/missing data: NoGaps, TimedGaps and EchoGaps.
             gapRendering = "TimedGaps";
 
-            // ########################## END of Pillaga Forest recordings
+            // ########################## END of FIX ISSUE #170 concat crashes
 
             /*
                         // ########################## CONCATENATION of Pillaga Forest recordings from Brad Law

--- a/src/AnalysisPrograms/Sandpit.cs
+++ b/src/AnalysisPrograms/Sandpit.cs
@@ -656,7 +656,7 @@ namespace AnalysisPrograms
 
             // SET DEFAULT COLOUR MAPS
             string colorMap1 = SpectrogramConstants.RGBMap_ACI_ENT_EVN;
-            string colorMap2 = SpectrogramConstants.RGBMap_BGN_PMN_R3D;
+            string colorMap2 = SpectrogramConstants.RGBMap_BGN_PMN_RHZ;
 
             // there are three options for rendering of gaps/missing data: NoGaps, TimedGaps and EchoGaps.
             string gapRendering = "TimedGaps"; // the default
@@ -734,26 +734,27 @@ namespace AnalysisPrograms
             // ######################### END OF CONCATENATION of MARINA SCARPELLI recordings from Brazil
 
             // ######################### START OF FIX ISSUE #170 concat crashes
-            // ######################### use data from availae 
+            // ######################### use data from availae
 
             // top level directory AVAILAE JOB #
             string[] dataDirs =
             {
-                @"Y:\Results\20180608-103353 - Tshering, Towsey.Indices, #216\Tshering\WBH_Walaytar\WBH_2018\Bermo",
+                //@"Y:\Results\20180608-103353 - Tshering, Towsey.Indices, #216\Tshering\WBH_Walaytar\WBH_2018\Bermo",
+                @"C:\Ecoacoustics\Output\Test\Test24HourRecording\TasmanIslandMez",
             };
 
-            string directoryFilter = "WAKLAYTAR_20180321_*.wav"; // this is a directory filter to locate only the required files
-            string opFileStem = "WAKLAYTAR_20180321";
+            string directoryFilter = "0*"; // this is a directory filter to locate only the required files
+            string opFileStem = "TasmanIslandMez";
             string opPath = @"C:\Ecoacoustics\Output\Test\DebugIssue170";
-            var falseColourSpgConfig = $"C:\\Work\\GitHub\\audio-analysis\\src\\AnalysisConfigFiles\\SpectrogramFalseColourConfig.yml";
+
+            // there are three options for rendering of gaps/missing data: NoGaps, TimedGaps and EchoGaps.
+            gapRendering = "TimedGaps";
             concatenateEverythingYouCanLayYourHandsOn = true;
+            var falseColourSpgConfig = $"C:\\Work\\GitHub\\audio-analysis\\src\\AnalysisConfigFiles\\SpectrogramFalseColourConfig.yml";
 
             // start and end dates INCLUSIVE
             //dtoStart = new DateTimeOffset(2016, 12, 31, 0, 0, 0, TimeSpan.Zero);
             //dtoEnd = new DateTimeOffset(2016, 12, 31, 0, 0, 0, TimeSpan.Zero);
-
-            // there are three options for rendering of gaps/missing data: NoGaps, TimedGaps and EchoGaps.
-            gapRendering = "TimedGaps";
 
             // ########################## END of FIX ISSUE #170 concat crashes
 

--- a/src/AudioAnalysisTools/Indices/GapsAndJoins.cs
+++ b/src/AudioAnalysisTools/Indices/GapsAndJoins.cs
@@ -50,7 +50,7 @@ namespace AudioAnalysisTools.Indices
         private static string gapDescriptionMissingData = "No Recording";
         private static string gapDescriptionZeroSignal = "ERROR: Zero Signal";
         private static string gapDescriptionInvalidValue = "Invalid Index Value";
-        private static string gapDescriptionFileJoin = "File Join";
+        public static string gapDescriptionFileJoin = "File Join";
 
         public string GapDescription { get; set; }
 
@@ -66,9 +66,9 @@ namespace AudioAnalysisTools.Indices
         /// <summary>
         /// Does several data integrity checks.
         /// </summary>
-        /// <param name="summaryIndices">a dictionary of summary indices</param>
-        /// <param name="gapRendering">describes how recording gaps are to be rendered</param>
-        /// <returns>a list of erroneous segments</returns>
+        /// <param name="summaryIndices">a dictionary of summary indices.</param>
+        /// <param name="gapRendering">describes how recording gaps are to be rendered.</param>
+        /// <returns>a list of erroneous segments.</returns>
         public static List<GapsAndJoins> DataIntegrityCheck(IEnumerable<SummaryIndexValues> summaryIndices, ConcatMode gapRendering)
         {
             // Integrity check 1: look for whether a recording minute exists
@@ -121,8 +121,8 @@ namespace AudioAnalysisTools.Indices
         /// This method reads through a SUMMARY index array to make sure there was actually a signal to analyse.
         /// If this occurs an gap/join event is flagged.
         /// </summary>
-        /// <param name="summaryIndices">array of summary indices</param>
-        /// <param name="gapRendering">how to render the gap in image terms</param>
+        /// <param name="summaryIndices">array of summary indices.</param>
+        /// <param name="gapRendering">how to render the gap in image terms.</param>
         /// <returns>a list of erroneous segments</returns>
         public static List<GapsAndJoins> DataIntegrityCheckForNoRecording(IEnumerable<SummaryIndexValues> summaryIndices, ConcatMode gapRendering)
         {
@@ -173,33 +173,22 @@ namespace AudioAnalysisTools.Indices
         /// <summary>
         /// This method reads through a SUMMARY index array to check for file joins.
         /// </summary>
-        /// <param name="summaryIndices">array of summary indices</param>
-        /// <param name="gapRendering">how to render the gap in image terms</param>
-        /// <returns>a list of erroneous segments</returns>
+        /// <param name="summaryIndices">array of summary indices.</param>
+        /// <param name="gapRendering">how to render the gap in image terms.</param>
+        /// <returns>a list of erroneous segments.</returns>
         public static List<GapsAndJoins> DataIntegrityCheckForFileJoins(IEnumerable<SummaryIndexValues> summaryIndices, ConcatMode gapRendering)
         {
            // init list of gaps and joins
             var gaps = new List<GapsAndJoins>();
-
-            //bool isValidBlock = true;
             var firstRow = summaryIndices.First();
             string previousFileName = firstRow.FileName;
-            //GapsAndJoins gap = null;
 
             // now loop through the rows/vectors of indices
             int index = 0;
             foreach (var row in summaryIndices)
             {
-                //if (previousFileName == null)
-                //{
-                //    previousFileName = row.FileName;
-                //}
-
                 if (row.FileName != previousFileName)
                 {
-                    //if (isValidBlock)
-                    //{
-                    //    isValidBlock = false;
                     var gap = new GapsAndJoins
                             {
                                 StartPosition = index,
@@ -207,24 +196,12 @@ namespace AudioAnalysisTools.Indices
                                 GapRendering = gapRendering,
                                 EndPosition = index + 1,
                             };
-                    //}
-                    //else
-                    //{
-                    //    // come to end of a bad patch
-                    //    isValidBlock = true;
-                    //}
                     gaps.Add(gap);
                     previousFileName = row.FileName;
                 }
 
                 index++;
             }
-
-            //// if not OK at end of the array, need to terminate the gap.
-            //if (!isValidBlock)
-            //{
-            //    gaps[gaps.Count - 1].EndPosition = gaps[gaps.Count - 1].EndPosition;
-            //}
 
             return gaps;
         }
@@ -240,7 +217,7 @@ namespace AudioAnalysisTools.Indices
         /// <returns>a list of erroneous segments</returns>
         public static List<GapsAndJoins> DataIntegrityCheckForZeroSignal(IEnumerable<SummaryIndexValues> summaryIndices)
         {
-            const double Tolerance = 0.0001;
+            const double tolerance = 0.0001;
 
             // init list of errors
             var errors = new List<GapsAndJoins>();
@@ -251,7 +228,7 @@ namespace AudioAnalysisTools.Indices
             foreach (var row in summaryIndices)
             {
                 // if (zeroSignal index > 0), i.e. if signal == zero
-                if (Math.Abs(row.ZeroSignal) > Tolerance)
+                if (Math.Abs(row.ZeroSignal) > tolerance)
                 {
                     if (allOk)
                     {
@@ -264,7 +241,7 @@ namespace AudioAnalysisTools.Indices
                         };
                     }
                 }
-                else if (!allOk && Math.Abs(row.ZeroSignal) < Tolerance)
+                else if (!allOk && Math.Abs(row.ZeroSignal) < tolerance)
                 {
                     // come to end of a bad patch
                     allOk = true;
@@ -292,7 +269,7 @@ namespace AudioAnalysisTools.Indices
         /// The tests done here are not particularly realistic and the chosen errors are possible unlikely to occur.
         /// TODO Other data integrity tests can be inserted in the future.
         /// </summary>
-        /// <param name="summaryIndices">Dictionary of the currently calculated summary indices</param>
+        /// <param name="summaryIndices">Dictionary of the currently calculated summary indices.</param>
         /// <returns>a list of erroneous segments</returns>
         public static List<GapsAndJoins> DataIntegrityCheckIndexValues(Dictionary<string, double[]> summaryIndices)
         {
@@ -360,9 +337,9 @@ namespace AudioAnalysisTools.Indices
         /// This test is not particularly realistic but might occur.
         /// Other tests can be inserted in the future.
         /// </summary>
-        /// <param name="spectralIndices">Dictionary of the currently calculated spectral indices</param>
-        /// <param name="gapRendering">how to render the gap in image terms</param>
-        /// <returns>a list of erroneous segments</returns>
+        /// <param name="spectralIndices">Dictionary of the currently calculated spectral indices.</param>
+        /// <param name="gapRendering">how to render the gap in image terms.</param>
+        /// <returns>a list of erroneous segments.</returns>
         public static List<GapsAndJoins> DataIntegrityCheckSpectralIndices(
             Dictionary<string, double[,]> spectralIndices,
             ConcatMode gapRendering)
@@ -422,17 +399,23 @@ namespace AudioAnalysisTools.Indices
         }
 
         /// <summary>
-        /// This method draws the error segments in in hierarchical order, highest level errors first.
+        /// This method draws error segments on false-colour spectrograms and/or summary index plots.
+        /// It draws them in hierarchical order, highest level errors first.
         /// This way error due to missing recording is drawn last and overwrites other casading errors due to missing recording.
         /// </summary>
         /// <param name="bmp">The chromeless spectrogram to have segments drawn on it.</param>
-        /// <param name="list">list of erroneous segments</param>
+        /// <param name="list">list of erroneous segments.</param>
+        /// <param name="drawFileJoins">drawing file joins is optional.</param>
         /// <returns>spectrogram with erroneous segments marked.</returns>
-        public static Image DrawErrorSegments(Image bmp, List<GapsAndJoins> list)
+        public static Image DrawErrorSegments(Image bmp, List<GapsAndJoins> list, bool drawFileJoins)
         {
             var newBmp = DrawGapPatches(bmp, list, gapDescriptionInvalidValue, bmp.Height, true);
             newBmp = DrawGapPatches(newBmp, list, gapDescriptionZeroSignal, bmp.Height, true);
-            newBmp = DrawFileJoins(newBmp, list);
+
+            if (drawFileJoins)
+            {
+                newBmp = DrawFileJoins(newBmp, list);
+            }
 
             // This one must be done last, in case user requests no gap rendering.
             // In this case, we have to cut out parts of image, starting at the end and working forward.
@@ -480,7 +463,7 @@ namespace AudioAnalysisTools.Indices
         public static Image DrawFileJoins(Image bmp, List<GapsAndJoins> errorList)
         {
             var g = Graphics.FromImage(bmp);
-            var pen = new Pen(Color.HotPink);
+            var pen = new Pen(Color.HotPink, 1);
 
             // assume errors are in temporal order and pull out in reverse order
             for (int i = errorList.Count - 1; i >= 0; i--)
@@ -499,15 +482,14 @@ namespace AudioAnalysisTools.Indices
         /// Draws a error patch based on properties of the error type.
         /// Depends on how gap rendering is to be done.
         /// </summary>
-        /// <param name="height">height in pixels of the error patch</param>
-        /// <param name="textInVerticalOrientation">orientation of error text should match orientation of the patch</param>
+        /// <param name="height">height in pixels of the error patch.</param>
+        /// <param name="textInVerticalOrientation">orientation of error text should match orientation of the patch.</param>
         public Bitmap DrawErrorPatch(int height, bool textInVerticalOrientation)
         {
             int width = this.EndPosition - this.StartPosition + 1;
             var bmp = new Bitmap(width, height);
             int fontVerticalPosition = (height / 2) - 10;
             var g = Graphics.FromImage(bmp);
-
             g.Clear(this.GapDescription == gapDescriptionMissingData ? Color.LightGray : Color.HotPink);
 
             // Draw error message and black cross over error patch only if is wider than arbitrary 10 pixels.
@@ -534,7 +516,7 @@ namespace AudioAnalysisTools.Indices
         }
 
         /// <summary>
-        /// Cuts out gap portion of a spectrogram image
+        /// Cuts out gap portion of a spectrogram image.
         /// </summary>
         public static Image RemoveGapPatch(Image source, GapsAndJoins error)
         {
@@ -564,7 +546,7 @@ namespace AudioAnalysisTools.Indices
         }
 
         /// <summary>
-        /// Draws an echo patch into a spectrogram image
+        /// Draws an echo patch into a spectrogram image.
         /// </summary>
         public static Image DrawEchoPatch(Image source, GapsAndJoins error)
         {

--- a/src/AudioAnalysisTools/Indices/IndexDisplay.cs
+++ b/src/AudioAnalysisTools/Indices/IndexDisplay.cs
@@ -73,8 +73,7 @@ namespace AudioAnalysisTools.Indices
                 dictionary,
                 titleText,
                 indexCalculationDuration,
-                recordingStartDate,
-                sunriseDataFile = null);
+                recordingStartDate);
         }
 
         /// <summary>
@@ -86,7 +85,6 @@ namespace AudioAnalysisTools.Indices
             string titleText,
             TimeSpan indexCalculationDuration,
             DateTimeOffset? recordingStartDate,
-            FileInfo sunriseDataFile = null,
             List<GapsAndJoins> errors = null,
             bool verbose = false)
         {
@@ -162,7 +160,7 @@ namespace AudioAnalysisTools.Indices
             {
                 // draw extra time scale with absolute start time. AND THEN Do SOMETHING WITH IT.
                 timeBmp2 = ImageTrack.DrawTimeTrack(fullDuration, dateTimeOffset, graphWidth, trackHeight);
-                suntrack = SunAndMoon.AddSunTrackToImage(scaleLength, dateTimeOffset, sunriseDataFile);
+                //suntrack = SunAndMoon.AddSunTrackToImage(scaleLength, dateTimeOffset, sunriseDataFile);
             }
 
             //draw the composite bitmap

--- a/src/AudioAnalysisTools/Indices/IndexDisplay.cs
+++ b/src/AudioAnalysisTools/Indices/IndexDisplay.cs
@@ -77,7 +77,7 @@ namespace AudioAnalysisTools.Indices
         }
 
         /// <summary>
-        /// Converts summary indices to a tracks image
+        /// Converts summary indices to a tracks image, one track for each index.
         /// </summary>
         public static Bitmap DrawImageOfSummaryIndices(
             Dictionary<string, IndexProperties> listOfIndexProperties,

--- a/src/AudioAnalysisTools/Indices/IndexMatrices.cs
+++ b/src/AudioAnalysisTools/Indices/IndexMatrices.cs
@@ -18,10 +18,10 @@ namespace AudioAnalysisTools.Indices
     using Acoustics.Shared;
     using Acoustics.Shared.Contracts;
     using Acoustics.Shared.Csv;
-    using log4net;
+    using DSP;
     using StandardSpectrograms;
+    using log4net;
     using TowseyLibrary;
-
     using Zio;
 
     public static class IndexMatrices
@@ -32,8 +32,8 @@ namespace AudioAnalysisTools.Indices
         /// <summary>
         /// All the passed files will be concatenated. Filtering needs to be done somewhere else.
         /// </summary>
-        /// <param name="files">array of file names</param>
-        /// <param name="indexCalcDuration">used to match rows of indices to elapsed time in file names</param>
+        /// <param name="files">array of file names.</param>
+        /// <param name="indexCalcDuration">used to match rows of indices to elapsed time in file names.</param>
         public static List<SummaryIndexValues> ConcatenateSummaryIndexFilesWithTimeCheck(FileInfo[] files, TimeSpan indexCalcDuration)
         {
             TimeSpan? offsetHint = new TimeSpan(10, 0, 0);
@@ -62,7 +62,6 @@ namespace AudioAnalysisTools.Indices
             var sourceFileNames = new HashSet<string>();
 
             // now loop through the files again to extract the indices
-            var missingRowCounter = 0;
             for (int i = 0; i < files.Length; i++)
             {
                 if (!files[i].Exists)
@@ -70,7 +69,6 @@ namespace AudioAnalysisTools.Indices
                     continue;
                 }
 
-                // Log.Debug("Reading of file started: " + files[i].FullName);
                 var rowsOfCsvFile = Csv.ReadFromCsv<SummaryIndexValues>(files[i], throwOnMissingField: false);
 
                 // check all rows have fileName set
@@ -154,8 +152,8 @@ namespace AudioAnalysisTools.Indices
 
         /// <summary>
         /// WARNING: THIS METHOD ONLY GETS FIXED LIST OF INDICES.
-        ///             Also it requires every index to be of type DOUBLE even when htis is not appropriate.
-        /// TODO: This needs to be generalized
+        ///             Also it requires every index to be of type DOUBLE even when this is not appropriate.
+        /// TODO: This needs to be generalized.
         /// </summary>
         public static Dictionary<string, double[]> GetDictionaryOfSummaryIndices(List<SummaryIndexValues> summaryIndices)
         {
@@ -227,7 +225,7 @@ namespace AudioAnalysisTools.Indices
         ///  i.e. check elapse time in file names against accumulated rows of indices.
         /// </summary>
         /// <param name="files">All the passed files will be concatenated. Filtering needs to be done somewhere else.</param>
-        /// <param name="indexCalcDuration">used to match rows of indices to elapsed time in file names</param>
+        /// <param name="indexCalcDuration">used to match rows of indices to elapsed time in file names.</param>
         /// <param name="key">this is used only in case need to write an error message. It identifies the key.</param>
         public static List<double[,]> ConcatenateSpectralIndexFilesWithTimeCheck(FileInfo[] files, TimeSpan indexCalcDuration, string key)
         {
@@ -309,9 +307,11 @@ namespace AudioAnalysisTools.Indices
                         {
                             for (int c = 0; c < columnCount; c++)
                             {
-                                // initialise with low decibel value
-                                // TODO: This should be set equal to a global constant somewhere. May need to change value to -150 dB.
-                                emptyMatrix[r, c] = -100.0;
+                                // initialise with zero signal decibel value
+                                emptyMatrix[r, c] = SNR.MinimumDbBoundForZeroSignal;
+
+                                // OR initialise with low decibel value for environmental noise
+                                //emptyMatrix[r, c] = SNR.MinimumDbBoundForEnvironmentalNoise;
                             }
                         }
                     }
@@ -454,7 +454,7 @@ namespace AudioAnalysisTools.Indices
         /// <summary>
         /// This method reads spectrogram csv files where the first row contains column names
         /// and the first column contains row/time names.
-        /// Note: no rotation of data is done!
+        /// Note: no rotation of data is done!.
         /// </summary>
         public static double[,] ReadSpectrogram(FileInfo csvFile, out int binCount)
         {
@@ -471,7 +471,7 @@ namespace AudioAnalysisTools.Indices
         /// <summary>
         /// Returns dictionary of spectral indices.
         /// Assumes both arrays of same length and keys correspond to file name.
-        /// TODO: Do this better one day!
+        /// TODO: Do this better one day!.
         /// </summary>
         public static Dictionary<string, double[,]> ReadSummaryIndexFiles(FileInfo[] files, string[] keys)
         {
@@ -479,8 +479,7 @@ namespace AudioAnalysisTools.Indices
             var dict = new Dictionary<string, double[,]>();
             for (int c = 0; c < count; c++)
             {
-                int freqBinCount;
-                double[,] matrix = ReadSpectrogram(files[c], out freqBinCount);
+                double[,] matrix = ReadSpectrogram(files[c], out var freqBinCount);
                 dict.Add(keys[c], matrix);
             }
 
@@ -500,7 +499,7 @@ namespace AudioAnalysisTools.Indices
                 .Where(x => x != null);
 
             // actual work done here
-            Stopwatch timer = Stopwatch.StartNew();
+            var timer = Stopwatch.StartNew();
 
             // ReSharper disable once PossibleInvalidOperationException
             var spectrogramMatrices = readData.ToDictionary(kvp => kvp.Value.Item1, kvp => kvp.Value.Item2);
@@ -527,10 +526,7 @@ namespace AudioAnalysisTools.Indices
                 double[,] matrix;
                 if (file.Exists)
                 {
-                    int freqBinCount;
-                    matrix = ReadSpectrogram(file, out freqBinCount, TwoDimensionalArray.Rotate90AntiClockWise);
-
-                    //matrix = MatrixTools.MatrixRotate90Anticlockwise(matrix);
+                    matrix = ReadSpectrogram(file, out var freqBinCount, TwoDimensionalArray.Rotate90AntiClockWise);
                 }
                 else
                 {
@@ -552,9 +548,9 @@ namespace AudioAnalysisTools.Indices
         /// This method got more complicated in June 2016 when it was refactored to cope with recording blocks less than
         /// one minute long.
         /// </summary>
-        /// <param name="spectra">The spectra to compress as a dictionary of spectrogram matrices</param>
-        /// <param name="imageScale">The scale (time resolution) of the compressed output spectrogram</param>
-        /// <param name="dataScale">The scale (time resolution) of the input spectral indices<see cref="spectra"/></param>
+        /// <param name="spectra">The spectra to compress as a dictionary of spectrogram matrices.</param>
+        /// <param name="imageScale">The scale (time resolution) of the compressed output spectrogram.</param>
+        /// <param name="dataScale">The scale (time resolution) of the input spectral indices<see cref="spectra"/>.</param>
         /// <param name="roundingFunc">
         /// How fractional spectra should be dealt with.
         /// It should be one of or similar to <see cref="Math.Round(double)"/>,
@@ -715,24 +711,30 @@ namespace AudioAnalysisTools.Indices
             return compressedSpectra;
         }
 
-        public static Dictionary<string, double[,]> ReadSpectrogramCSVFiles(DirectoryInfo ipdir, string fileName, string indexKeys, out int freqBinCount)
+        public static Dictionary<string, double[,]> ReadSpectrogramCsvFiles(DirectoryInfo ipdir, string fileName, string indexKeys, out int freqBinCount)
         {
             string[] keys = indexKeys.Split('-');
-            return ReadSpectrogramCSVFiles(ipdir, fileName, keys, out freqBinCount);
+            return ReadSpectrogramCsvFiles(ipdir, fileName, keys, out freqBinCount);
         }
 
-        public static Dictionary<string, double[,]> ReadSpectrogramCSVFiles(DirectoryInfo ipdir, string fileName, string[] keys, out int freqBinCount)
+        /// <summary>
+        /// Reads a list of Spectrogram Csv Files.
+        /// </summary>
+        /// <param name="ipdir">input dir.</param>
+        /// <param name="fileName">the file name.</param>
+        /// <param name="keys">an array of keys.</param>
+        /// <param name="freqBinCount">number of freq bins.</param>
+        public static Dictionary<string, double[,]> ReadSpectrogramCsvFiles(DirectoryInfo ipdir, string fileName, string[] keys, out int freqBinCount)
         {
             var dict = new Dictionary<string, double[,]>();
             string warning = null;
-            freqBinCount = 256; // the default
+            freqBinCount = 256;
             for (int key = 0; key < keys.Length; key++)
             {
                 var file = new FileInfo(Path.Combine(ipdir.FullName, fileName + "." + keys[key] + ".csv"));
                 if (file.Exists)
                 {
-                    int binCount;
-                    double[,] matrix = ReadSpectrogram(file, out binCount);
+                    double[,] matrix = ReadSpectrogram(file, out var binCount);
                     matrix = MatrixTools.MatrixRotate90Anticlockwise(matrix);
                     dict.Add(keys[key], matrix);
                     freqBinCount = binCount;
@@ -741,7 +743,7 @@ namespace AudioAnalysisTools.Indices
                 {
                     if (warning == null)
                     {
-                        warning = "\nWARNING: from method IndexMatrices.ReadSpectrogramCSVFiles()";
+                        warning = "\nWARNING: from method IndexMatrices.ReadSpectrogramCsvFiles()";
                     }
 
                     warning += $"\n      {keys[key]} File does not exist: {file.FullName}";
@@ -758,7 +760,7 @@ namespace AudioAnalysisTools.Indices
                 return dict;
             }
 
-            LoggedConsole.WriteLine("WARNING: from method IndexMatrices.ReadSpectrogramCSVFiles()");
+            LoggedConsole.WriteLine("WARNING: from method IndexMatrices.ReadSpectrogramCsvFiles()");
             LoggedConsole.WriteLine("         NO FILES were read from this directory: " + ipdir);
 
             return dict;

--- a/src/AudioAnalysisTools/Indices/IndexProperties.cs
+++ b/src/AudioAnalysisTools/Indices/IndexProperties.cs
@@ -327,6 +327,7 @@ namespace AudioAnalysisTools.Indices
                     if (errorBmp != null)
                     {
                         g.DrawImage(errorBmp, errorSegment.StartPosition, 1);
+                        //newBmp = DrawFileJoins(newBmp, list);
                     }
                 }
             }

--- a/src/AudioAnalysisTools/Indices/IndexProperties.cs
+++ b/src/AudioAnalysisTools/Indices/IndexProperties.cs
@@ -107,11 +107,10 @@ namespace AudioAnalysisTools.Indices
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IndexProperties"/> class.
-        /// constructor sets default values
+        /// constructor sets default values.
         /// </summary>
         public IndexProperties()
         {
-            // TODO: why not initialise these to null, the proper empty value?
             this.Key = "NOT SET";
             this.Name = string.Empty;
             this.DataType = "double";
@@ -148,7 +147,7 @@ namespace AudioAnalysisTools.Indices
 
         [YamlIgnore]
         [JsonIgnore]
-        // TODO: this information should really be encoded rather than inferred
+        //TODO: this information should really be encoded rather than inferred
         public bool IsSpectralIndex => this.DataType == "double[]";
 
         public double DefaultValue
@@ -197,73 +196,44 @@ namespace AudioAnalysisTools.Indices
 
         public double ComboWeight { get; set; }
 
-        private void UpdateTypedDefault()
-        {
-            if (this.DataType == "int")
-            {
-                this.DefaultValueCasted = (int)this.DefaultValue;
-            }
-            else if (this.DataType == "double" || this.dataType == "double[]")
-            {
-                this.DefaultValueCasted = this.DefaultValue;
-            }
-            else if (this.DataType == "TimeSpan")
-            {
-                this.DefaultValueCasted = TimeSpan.FromSeconds(this.DefaultValue);
-            }
-            else
-            {
-                throw new InvalidOperationException("Unknown data type");
-            }
-        }
-
-        public double NormaliseValue(double value)
-        {
-            return DataTools.NormaliseInZeroOne(value, this.NormMin, this.NormMax);
-        }
-
-       //public double[,] NormaliseIndexValues(double[,] M)
-        //{
-        //    return MatrixTools.NormaliseInZeroOne(M, this.NormMin, this.NormMax);
-        //}
+        public double NormaliseValue(double value) => DataTools.NormaliseInZeroOne(value, this.NormMin, this.NormMax);
 
         /// <summary>
-        /// Units for indices include: dB, ms, % and dimensionless
+        /// Units for indices include: dB, ms, % and dimensionless.
         /// </summary>
         public string GetPlotAnnotation()
         {
             if (this.Units == string.Empty)
             {
-                return string.Format(" {0} ({1:f2} .. {2:f2} {3})", this.Name, this.NormMin, this.NormMax, this.Units);
+                return $" {this.Name} ({this.NormMin:f2} .. {this.NormMax:f2} {this.Units})";
             }
 
             if (this.Units == "%")
             {
-                return string.Format(" {0} ({1:f0} .. {2:f0}{3})", this.Name, this.NormMin, this.NormMax, this.Units);
+                return $" {this.Name} ({this.NormMin:f0} .. {this.NormMax:f0}{this.Units})";
             }
 
             if (this.Units == "dB")
             {
-                return string.Format(" {0} ({1:f0} .. {2:f0} {3})", this.Name, this.NormMin, this.NormMax, this.Units);
+                return $" {this.Name} ({this.NormMin:f0} .. {this.NormMax:f0} {this.Units})";
             }
 
             if (this.Units == "ms")
             {
-                return string.Format(" {0} ({1:f0} .. {2:f0}{3})", this.Name, this.NormMin, this.NormMax, this.Units);
+                return $" {this.Name} ({this.NormMin:f0} .. {this.NormMax:f0}{this.Units})";
             }
 
             if (this.Units == "s")
             {
-                return string.Format(" {0} ({1:f1} .. {2:f1}{3})", this.Name, this.NormMin, this.NormMax, this.Units);
+                return $" {this.Name} ({this.NormMin:f1} .. {this.NormMax:f1}{this.Units})";
             }
 
-            return string.Format(" {0} ({1:f2} .. {2:f2} {3})", this.Name, this.NormMin, this.NormMax, this.Units);
+            return $" {this.Name} ({this.NormMin:f2} .. {this.NormMax:f2} {this.Units})";
         }
 
         /// <summary>
-        /// For writing this method:
-        ///    See CLASS: DrawSummaryIndices
-        ///       METHOD: Bitmap ConstructVisualIndexImage(DataTable dt, string title, int timeScale, double[] order, bool doNormalise)
+        /// This method called from Indexdisplay.DrawImageOfSummaryIndices().
+        /// It draws a single plot/track of one summary index.
         /// </summary>
         public Image GetPlotImage(double[] array, List<GapsAndJoins> errors = null)
         {
@@ -312,24 +282,16 @@ namespace AudioAnalysisTools.Indices
                 bmp.SetPixel(i, 0, Color.Gray);
             }
 
-            // end over all pixels
             int endWidth = trackWidth - dataLength;
             var font = new Font("Arial", 9.0f, FontStyle.Regular);
             g.FillRectangle(Brushes.Black, dataLength + 1, 0, endWidth, trackHeight);
             g.DrawString(annotation, font, Brushes.White, new PointF(dataLength + 5, 2));
 
-            // now add in image patches for possible erroneous index segments
-            if (errors != null && errors.Count > 0)
+            // now add in image patches for possible erroneous segments
+            bool errorsExist = errors != null && errors.Count > 0;
+            if (errorsExist)
             {
-                foreach (GapsAndJoins errorSegment in errors)
-                {
-                    var errorBmp = errorSegment.DrawErrorPatch(trackHeight - 2, textInVerticalOrientation: false);
-                    if (errorBmp != null)
-                    {
-                        g.DrawImage(errorBmp, errorSegment.StartPosition, 1);
-                        //newBmp = DrawFileJoins(newBmp, list);
-                    }
-                }
+                bmp = (Bitmap)GapsAndJoins.DrawErrorSegments(bmp, errors, false);
             }
 
             return bmp;
@@ -337,7 +299,7 @@ namespace AudioAnalysisTools.Indices
 
         /// <summary>
         /// Returns a cached set of configuration properties.
-        /// WARNING CACHED!
+        /// WARNING CACHED!.
         /// </summary>
         public static IndexPropertiesCollection GetIndexProperties(FileInfo configFile)
         {
@@ -388,6 +350,26 @@ namespace AudioAnalysisTools.Indices
                 out var configFile);
 
             return found ? configFile : null;
+        }
+
+        private void UpdateTypedDefault()
+        {
+            if (this.DataType == "int")
+            {
+                this.DefaultValueCasted = (int)this.DefaultValue;
+            }
+            else if (this.DataType == "double" || this.dataType == "double[]")
+            {
+                this.DefaultValueCasted = this.DefaultValue;
+            }
+            else if (this.DataType == "TimeSpan")
+            {
+                this.DefaultValueCasted = TimeSpan.FromSeconds(this.DefaultValue);
+            }
+            else
+            {
+                throw new InvalidOperationException("Unknown data type");
+            }
         }
     }
 }

--- a/src/AudioAnalysisTools/Indices/SpectralIndicesToAndFromTable.cs
+++ b/src/AudioAnalysisTools/Indices/SpectralIndicesToAndFromTable.cs
@@ -138,7 +138,7 @@ namespace AudioAnalysisTools.Indices
 
             // reads all known files spectral indices
             int freqBinCount;
-            Dictionary<string, double[,]> dict = IndexMatrices.ReadSpectrogramCSVFiles(targetDirInfo, targetFileName, spectrogramKeys, out freqBinCount);
+            Dictionary<string, double[,]> dict = IndexMatrices.ReadSpectrogramCsvFiles(targetDirInfo, targetFileName, spectrogramKeys, out freqBinCount);
 
             if (dict.Count() == 0)
             {

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -375,7 +375,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         public bool ReadStandardDeviationSpectrogramCsvs(DirectoryInfo ipdir, string fileName)
         {
             int freqBinCount;
-            this.spgrStdDevMatrices = IndexMatrices.ReadSpectrogramCSVFiles(ipdir, fileName, this.ColorMap, out freqBinCount);
+            this.spgrStdDevMatrices = IndexMatrices.ReadSpectrogramCsvFiles(ipdir, fileName, this.ColorMap, out freqBinCount);
             this.FrameWidth = freqBinCount * 2;
             if (this.spgrStdDevMatrices == null)
             {
@@ -630,7 +630,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             bool errorsExist = this.ErroneousSegments != null && this.ErroneousSegments.Count > 0;
             if (errorsExist)
             {
-                bmp = GapsAndJoins.DrawErrorSegments(bmp, this.ErroneousSegments);
+                bmp = GapsAndJoins.DrawErrorSegments(bmp, this.ErroneousSegments, false);
             }
 
             return bmp;

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramStitching.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramStitching.cs
@@ -186,7 +186,6 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                                  titletext,
                                  indexGenerationData.IndexCalculationDuration,
                                  indexGenerationData.RecordingStartDate,
-                                 sunriseDatafile,
                                  erroneousSegments,
                                  verbose);
             var imagePath = FilenameHelpers.AnalysisResultPath(opDir, opFileStem, SummaryIndicesStr, ImgFileExt);

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/SpectrogramConstants.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/SpectrogramConstants.cs
@@ -28,6 +28,8 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         public const string RGBMap_BGN_PMN_EVN = "BGN-PMN-EVN"; //R-G-B
         public const string RGBMap_BGN_PMN_SPT = "BGN-PMN-SPT"; //R-G-B
         public const string RGBMap_BGN_PMN_CLS = "BGN-PMN-CLS"; //R-G-B
+        public const string RGBMap_BGN_PMN_OSC = "BGN-PMN-OSC";
+        public const string RGBMap_BGN_PMN_RHZ = "BGN-PMN-RHZ";
         public const string RGBMap_BGN_PMN_R3D = "BGN-PMN-R3D";
         public const string RGBMap_BGN_PMN_CVR = "BGN-PMN-CVR"; //R-G-B
 

--- a/tests/Acoustics.Test/InfiniteTextStreamTests.cs
+++ b/tests/Acoustics.Test/InfiniteTextStreamTests.cs
@@ -52,7 +52,7 @@ namespace Acoustics.Test
                 }
             }
 
-            var work = Task.Run(Generate, token);
+            var work = Task.Run((Action)Generate, token);
 
             Assert.IsFalse(work.IsCompleted);
             source.CancelAfter(this.timeout);


### PR DESCRIPTION
Issue #170 and Issue #212 should now both be fixed.
Concatenated LDFC spectrograms do not show file joins but Concatenated summary index images do show file joins. Have previously included image showing what file joins now look like.