### PR TITLE
Enhances audio cutter

### DIFF
--- a/src/AnalysisPrograms/AudioCutter.cs
+++ b/src/AnalysisPrograms/AudioCutter.cs
@@ -15,13 +15,19 @@ namespace AnalysisPrograms
     using Acoustics.Shared;
     using AnalysisBase;
     using AnalysisBase.Segment;
+    using AnalysisPrograms.Production;
+    using AnalysisPrograms.Production.Arguments;
+    using AnalysisPrograms.Production.Validation;
+    using AnalysisPrograms.SourcePreparers;
     using McMaster.Extensions.CommandLineUtils;
     using McMaster.Extensions.CommandLineUtils.Abstractions;
-    using Production;
-    using Production.Arguments;
-    using Production.Validation;
-    using SourcePreparers;
 
+    /// <summary>
+    /// Cuts a file into smaller segments.
+    /// </summary>
+    /// <remarks>
+    /// This cutter is useful when you want audio cut the same way AP.exe cuts it.
+    /// </remarks>
     public class AudioCutter
     {
         public const string CommandName = "AudioCutter";
@@ -74,21 +80,21 @@ namespace AnalysisPrograms
             public double? EndOffset { get; set; }
 
             [Option(
-                Description = "The minimum duration of a segmented audio file (in seconds, defaults to 5; must be within [0, 3600]).",
+                Description = "The minimum duration of a segmented audio file (in seconds, defaults to 5; must be within [1, 3600]).",
                 ShortName = "")]
             [InRange(1, 3600)]
             public double SegmentDurationMinimum { get; set; } = 5;
 
             [Option(
-                Description = "The duration of a segmented audio file (in seconds, defaults to 60; must be within [0, 3600]).",
+                Description = "The duration of a segmented audio file (in seconds, defaults to 60; must be within [1, 43200]).",
                 ShortName = "d")]
-            [InRange(1, 3600)]
+            [InRange(1, 12 * 3600)]
             public double SegmentDuration { get; set; } = 60;
 
             [Option(
-                Description = "The duration of overlap between segmented audio files (in seconds, defaults to 0).",
+                Description = "The duration of overlap between segmented audio files (in seconds, defaults to 0; must be within [0, 43200]).",
                 ShortName = "")]
-            [InRange(0, 3600)]
+            [InRange(0, 43200)]
             public double SegmentOverlap { get; set; } = 0;
 
             [Option(

--- a/src/AnalysisPrograms/Production/Validation/InRangeAttribute.cs
+++ b/src/AnalysisPrograms/Production/Validation/InRangeAttribute.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InRangeAttribute.cs" company="QutEcoacoustics">
+// <copyright file="InRangeAttribute.cs" company="QutEcoacoustics">
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
 
@@ -36,7 +36,7 @@ namespace AnalysisPrograms.Production.Validation
             {
                 if (!double.TryParse(str, out number))
                 {
-                    return new ValidationResult($"The number {number} for argument {validationContext.DisplayName} can not be parsed as a number.");
+                    return new ValidationResult($"The number {number} for argument {validationContext.DisplayName} can not be parsed as a number.", validationContext.MemberName.AsArray());
                 }
             }
             else if (value is double)
@@ -45,22 +45,22 @@ namespace AnalysisPrograms.Production.Validation
             }
             else
             {
-                return new ValidationResult($"The value {value} for argument {validationContext.DisplayName} can not be parsed as a number.");
+                return new ValidationResult($"The value {value} for argument {validationContext.DisplayName} can not be parsed as a number.", validationContext.MemberName.AsArray());
             }
 
             if (double.IsNaN(number))
             {
-                return new ValidationResult($"The number {number} for argument {validationContext.DisplayName} is not valid");
+                return new ValidationResult($"The number {number} for argument {validationContext.DisplayName} is not valid", validationContext.MemberName.AsArray());
             }
 
             if (number > this.max)
             {
-                return new ValidationResult($"The number {number} for argument {validationContext.DisplayName} is greater than allowed limit {this.max}");
+                return new ValidationResult($"The number {number} for argument {validationContext.DisplayName} is greater than allowed limit {this.max}", validationContext.MemberName.AsArray());
             }
 
             if (number < this.min)
             {
-                return new ValidationResult($"The number {number} for argument {validationContext.DisplayName} is less than allowed limit {this.min}");
+                return new ValidationResult($"The number {number} for argument {validationContext.DisplayName} is less than allowed limit {this.min}", validationContext.MemberName.AsArray());
             }
 
             return ValidationResult.Success;


### PR DESCRIPTION
Closes #223

Manually tested 2 hour segment cuts on `Y:\Tshering\WBH_Walaytar\WBH_2017\Ada Lake\Card1_20170201\ADA_20170201_000036.wav.`