### PR TITLE
Tried to improve check environment

### DIFF
--- a/src/Acoustics.Shared/AppConfigHelper.cs
+++ b/src/Acoustics.Shared/AppConfigHelper.cs
@@ -38,7 +38,17 @@ namespace Acoustics.Shared
         private static readonly string ExecutingAssemblyPath =
             (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly()).Location;
 
-        private static readonly IConfigurationSection SharedSettings;
+        private static readonly Lazy<IConfigurationSection> SharedSettings = new Lazy<IConfigurationSection>(() =>
+        {
+            var settings = AppConfiguration.Value.GetSection("appSettings");
+            if (!settings.AsEnumerable().Any())
+            {
+                throw new ConfigurationErrorsException("Could not read AP.Settings.json - no values were found in the config file");
+            }
+
+            return settings;
+        });
+
         private static readonly ILog Log = LogManager.GetLogger(nameof(AppConfigHelper));
         private static readonly bool IsLinuxValue;
         private static readonly bool IsWindowsValue;
@@ -46,21 +56,14 @@ namespace Acoustics.Shared
 
         static AppConfigHelper()
         {
-            AppConfiguration = new ConfigurationBuilder()
-                .AddJsonFile("AP.Settings.json")
-                .Build();
-
-            SharedSettings = AppConfiguration.GetSection("appSettings");
-            if (!SharedSettings.AsEnumerable().Any())
-            {
-                throw new ConfigurationErrorsException("Could not read AP.Settings.json - no values were found in the config file");
-            }
-
             IsMono = Type.GetType("Mono.Runtime") != null;
             CheckOs(ref IsWindowsValue, ref IsLinuxValue, ref IsMacOsXValue);
         }
 
-        public static IConfigurationRoot AppConfiguration { get; }
+        public static Lazy<IConfigurationRoot> AppConfiguration { get; } = new Lazy<IConfigurationRoot>(() =>
+            new ConfigurationBuilder()
+                .AddJsonFile("AP.Settings.json")
+                .Build());
 
         public static int DefaultTargetSampleRate => GetInt(DefaultTargetSampleRateKey);
 
@@ -166,7 +169,7 @@ namespace Acoustics.Shared
 
         public static string GetString(string key)
         {
-            var value = SharedSettings[key];
+            var value = SharedSettings.Value[key];
 
             if (string.IsNullOrEmpty(value))
             {
@@ -333,7 +336,7 @@ namespace Acoustics.Shared
                 key = appConfigKey;
             }
 
-            var path = SharedSettings[key];
+            var path = SharedSettings.Value[key];
 
             Log.Verbose($"Attempted to get exe path `{appConfigKey}`. Value: '{path}'");
 

--- a/src/Acoustics.Shared/app.config
+++ b/src/Acoustics.Shared/app.config
@@ -2,6 +2,218 @@
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.XmlSerializer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Timer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Overlapped" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.RegularExpressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.Encoding.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.Encoding" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.SecureString" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.Principal" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Serialization.Xml" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Serialization.Json" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Numerics" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Resources.ResourceManager" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ObjectModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Sockets" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Requests" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.NetworkInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq.Queryable" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq.Expressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.IO" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.IO.Compression" publicKeyToken="B77A5C561934E089" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Globalization.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Globalization" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Dynamic.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Tools" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Debug" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Contracts" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Data.Common" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ComponentModel.EventBasedAsync" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ComponentModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections.Concurrent" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="YamlDotNet" publicKeyToken="2b53052c5884d7a1" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-2.0.1.21004" newVersion="2.0.1.21004"/>

--- a/src/AnalysisPrograms/AnalysisPrograms.csproj
+++ b/src/AnalysisPrograms/AnalysisPrograms.csproj
@@ -136,7 +136,9 @@
       <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Console">

--- a/src/AnalysisPrograms/MainEntry.cs
+++ b/src/AnalysisPrograms/MainEntry.cs
@@ -36,7 +36,7 @@ namespace AnalysisPrograms
 
             Copyright();
 
-            AttachExceptionHandler();
+            PrepareForErrors();
 
             NoConsole.Log.Info($"Executable called with these arguments: {NewLine}{CommandLine}{NewLine}");
 

--- a/src/AnalysisPrograms/Production/Exceptions.cs
+++ b/src/AnalysisPrograms/Production/Exceptions.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Exceptions.cs" company="QutEcoacoustics">
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
@@ -19,102 +19,96 @@ namespace AnalysisPrograms.Production
     public static class ExceptionLookup
     {
         /// <summary>
-        /// The default exit code to use for exceptions not recognised. Must not be greater than 255.
+        /// The default exit code to use for exceptions not recognized. Must not be greater than 255.
         /// </summary>
         public const int UnhandledExceptionErrorCode = 200;
 
-        internal static readonly Dictionary<Type, ExceptionStyle> ErrorLevels;
-
-        static ExceptionLookup()
-        {
-            // WARNING: EXIT CODES CANNOT BE > 255 (for linux compatibility)
-            ErrorLevels = new Dictionary<Type, ExceptionStyle>
-                              {
-                                  {
-                                      typeof(ValidationException),
-                                      new ExceptionStyle { ErrorCode = ValiationError, PrintUsage = false }
-                                  },
-                                  {
-                                      typeof(CommandLineArgumentException),
-                                      new ExceptionStyle() { ErrorCode = 3 }
-                                  },
-                                  {
-                                      typeof(CommandParsingException),
-                                      new ExceptionStyle() { ErrorCode = 4 }
-                                  },
-                                  {
-                                      typeof(DirectoryNotFoundException),
-
-                                      // disabled print usage because these exceptions happen at all levels of the stack
-                                      new ExceptionStyle { ErrorCode = 51, PrintUsage = false }
-                                  },
-                                  {
-                                      typeof(FileNotFoundException),
-
-                                      // disabled print usage because these exceptions happen at all levels of the stack
-                                      new ExceptionStyle { ErrorCode = 52, PrintUsage = false }
-                                  },
-                                  {
-                                      typeof(InvalidDurationException),
-                                      new ExceptionStyle { ErrorCode = 100 }
-                                  },
-                                  {
-                                      typeof(InvalidStartOrEndException),
-                                      new ExceptionStyle { ErrorCode = 101 }
-                                  },
-                                  {
-                                      typeof(InvalidFileDateException),
-                                      new ExceptionStyle() { ErrorCode = 102, PrintUsage = false }
-                                  },
-                                  {
-                                      typeof(ConfigFileException),
-                                      new ExceptionStyle() { ErrorCode = 103, PrintUsage = false }
-                                  },
-                                  {
-                                      typeof(AudioRecordingTooShortException),
-                                      new ExceptionStyle() { ErrorCode = 104, PrintUsage = false }
-                                  },
-                                  {
-                                      typeof(InvalidAudioChannelException),
-                                      new ExceptionStyle() { ErrorCode = 105, PrintUsage = false }
-                                  },
-                                  {
-                                      typeof(AnalysisOptionDevilException),
-                                      new ExceptionStyle
-                                          {
-                                              ErrorCode = 66,
-                                              Handle = false,
-                                          }
-                                  },
-                                  {
-                                      typeof(NoDeveloperMethodException),
-                                      new ExceptionStyle { ErrorCode = 199 }
-                                  },
-                                  {
-                                      typeof(Exception),
-                                      new ExceptionStyle
-                                          {
-                                              ErrorCode =
-                                                  UnhandledExceptionErrorCode,
-                                          }
-                                  },
-                              };
-        }
+        private static Dictionary<Type, ExceptionStyle> levels;
 
         public static int Ok => 0;
 
-        public static int ValiationError => 2;
+        public static int ValidationError => 2;
 
         public static int ActionRequired => 2;
 
         public static int NoData => 10;
 
-        public static int SpecialExceptionErrorLevel
+        internal static Dictionary<Type, ExceptionStyle> ErrorLevels => levels ?? (levels = CreateExceptionMap());
+
+        private static Dictionary<Type, ExceptionStyle> CreateExceptionMap()
         {
-            get
+            // WARNING: EXIT CODES CANNOT BE > 255 (for linux compatibility)
+            return new Dictionary<Type, ExceptionStyle>
             {
-                return ErrorLevels[typeof(Exception)].ErrorCode;
-            }
+                {
+                    typeof(ValidationException),
+                    new ExceptionStyle { ErrorCode = ValidationError, PrintUsage = false }
+                },
+                {
+                    typeof(CommandLineArgumentException),
+                    new ExceptionStyle() { ErrorCode = 3 }
+                },
+                {
+                    typeof(CommandParsingException),
+                    new ExceptionStyle() { ErrorCode = 4 }
+                },
+                {
+                    typeof(DirectoryNotFoundException),
+
+                    // disabled print usage because these exceptions happen at all levels of the stack
+                    new ExceptionStyle { ErrorCode = 51, PrintUsage = false }
+                },
+                {
+                    typeof(FileNotFoundException),
+
+                    // disabled print usage because these exceptions happen at all levels of the stack
+                    new ExceptionStyle { ErrorCode = 52, PrintUsage = false }
+                },
+                {
+                    typeof(InvalidDurationException),
+                    new ExceptionStyle { ErrorCode = 100 }
+                },
+                {
+                    typeof(InvalidStartOrEndException),
+                    new ExceptionStyle { ErrorCode = 101 }
+                },
+                {
+                    typeof(InvalidFileDateException),
+                    new ExceptionStyle() { ErrorCode = 102, PrintUsage = false }
+                },
+                {
+                    typeof(ConfigFileException),
+                    new ExceptionStyle() { ErrorCode = 103, PrintUsage = false }
+                },
+                {
+                    typeof(AudioRecordingTooShortException),
+                    new ExceptionStyle() { ErrorCode = 104, PrintUsage = false }
+                },
+                {
+                    typeof(InvalidAudioChannelException),
+                    new ExceptionStyle() { ErrorCode = 105, PrintUsage = false }
+                },
+                {
+                    typeof(AnalysisOptionDevilException),
+                    new ExceptionStyle
+                    {
+                        ErrorCode = 66,
+                        Handle = false,
+                    }
+                },
+                {
+                    typeof(NoDeveloperMethodException),
+                    new ExceptionStyle { ErrorCode = 199 }
+                },
+                {
+                    typeof(Exception),
+                    new ExceptionStyle
+                    {
+                        ErrorCode =
+                            UnhandledExceptionErrorCode,
+                    }
+                },
+            };
         }
 
         public class ExceptionStyle

--- a/src/AnalysisPrograms/Production/MainEntryUtilities.cs
+++ b/src/AnalysisPrograms/Production/MainEntryUtilities.cs
@@ -199,6 +199,36 @@ namespace AnalysisPrograms
             LoadNativeCode();
         }
 
+        /// <summary>
+        /// Checks to see whether we can load a DLL that we depend on from the GAC.
+        /// We have to check this early on or else we get some pretty hard to
+        /// diagnose errors (and also because our CLI parser depends on it).
+        /// </summary>
+        /// <returns>A message if there is a problem.</returns>
+        internal static string CheckForDataAnnotations()
+        {
+            // https://github.com/QutEcoacoustics/audio-analysis/issues/225
+            try
+            {
+                Assembly.Load(
+                    "System.ComponentModel.DataAnnotations, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35");
+                return null;
+            }
+            catch (FileNotFoundException fnfex)
+            {
+                return $@"{fnfex.ToString()}
+!
+!
+!
+In cases where System.ComponentModel.DataAnnotations is not found we have
+previously found that the mono install is corrupt. Try installing mono again
+and make sure you install the `mono-complete` package.
+!
+!
+!";
+            }
+        }
+
         internal static void Copyright()
         {
             LoggedConsole.WriteLine(
@@ -338,9 +368,19 @@ namespace AnalysisPrograms
             return app;
         }
 
-        private static void AttachExceptionHandler()
+        /// <summary>
+        /// Attaches an exception handler and also does a check
+        /// to see if necessary DLLs exist. WARNING: can quit process!.
+        /// </summary>
+        private static void PrepareForErrors()
         {
-            Environment.ExitCode = ExceptionLookup.SpecialExceptionErrorLevel;
+            ExitCode = ExceptionLookup.UnhandledExceptionErrorCode;
+
+            if (CheckForDataAnnotations() is string message)
+            {
+                Console.WriteLine(message);
+                Exit(ExceptionLookup.UnhandledExceptionErrorCode);
+            }
 
             AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledException;
         }
@@ -403,7 +443,7 @@ namespace AnalysisPrograms
                 PrintAggregateException(ex);
             }
 
-            int returnCode = style?.ErrorCode ?? ExceptionLookup.SpecialExceptionErrorLevel;
+            int returnCode = style?.ErrorCode ?? ExceptionLookup.UnhandledExceptionErrorCode;
 
             // finally return error level
             NoConsole.Log.Info("ERRORLEVEL: " + returnCode);

--- a/src/AnalysisPrograms/packages.config
+++ b/src/AnalysisPrograms/packages.config
@@ -39,6 +39,7 @@
   <package id="System.AppContext" version="4.3.0" targetFramework="net462" />
   <package id="System.Collections" version="4.3.0" targetFramework="net462" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net462" />
+  <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net462" />
   <package id="System.Console" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />


### PR DESCRIPTION
It now delays execution of a few things in AppConfigHelper so we can do more checks before crashing.

Check environment actually checks the mono version now, and multiple errors could happen as well to make the check-fix routine easier.

Intended to help dx #225 

@Allcharles can you test the appveyor build on your install. I've made this fix so AP.exe can at least get started long enough to provide a better error (user needs better mono version).

