### PR TITLE
Issue #192 add ldfc properties to acoustic config

### DIFF
--- a/src/AnalysisBase/AnalyzerConfig.cs
+++ b/src/AnalysisBase/AnalyzerConfig.cs
@@ -1,9 +1,10 @@
-﻿// <copyright file="AnalyzerConfig.cs" company="QutEcoacoustics">
+// <copyright file="AnalyzerConfig.cs" company="QutEcoacoustics">
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
 
 namespace AnalysisBase
 {
+    using System.IO;
     using Acoustics.Shared.ConfigFile;
 
     public class AnalyzerConfig
@@ -16,12 +17,12 @@ namespace AnalysisBase
         public double EventThreshold { get; set; } = EventThresholdDefault;
 
         /// <summary>
-        /// Gets or sets the length of audio block to process
+        /// Gets or sets the length of audio block to process.
         /// </summary>
         public double? SegmentDuration { get; set; }
 
         /// <summary>
-        /// Gets or sets the amount that each audio block should overlap
+        /// Gets or sets the amount that each audio block should overlap.
         /// </summary>
         public double? SegmentOverlap { get; set; }
 
@@ -45,7 +46,7 @@ namespace AnalysisBase
         public SaveBehavior SaveSonogramImages { get; set; } = SaveBehavior.Never;
 
         /// <summary>
-        /// Gets or sets a value indicating whether a file must have a date in the file name
+        /// Gets or sets a value indicating whether a file must have a date in the file name.
         /// </summary>
         /// <remarks>
         /// if true, an unambiguous date time must be provided in the source file's name.
@@ -55,7 +56,7 @@ namespace AnalysisBase
         ///     prefix_20140101T235959+1000.mp3
         ///     prefix_20140101T235959+Z.mp3
         ///     prefix_20140101-235959+1000.mp3
-        ///     prefix_20140101-235959+Z.mp3
+        ///     prefix_20140101-235959+Z.mp3.
         /// </remarks>
         public bool RequireDateInFilename { get; set; } = false;
     }

--- a/src/AnalysisConfigFiles/Towsey.Acoustic.yml
+++ b/src/AnalysisConfigFiles/Towsey.Acoustic.yml
@@ -101,5 +101,33 @@ IndexPropertiesConfig: './IndexPropertiesConfig.yml'
 # This value can sometimes be used to manage the FP/FN trade-off performance of a call recogniser.
 # Not always used however. 
 EventThreshold: 0.2
+
+# #############################################################################################################
+# The below parameters are used to configure drawing of the false-colour spectrograms
+# IMPORTANT NOTE: FC spectrograms are produced only IF the above IndexCalculationDuration := 60.0
+# Explanation of the FC configuration parameters is included below.
+LdSpectrogramConfig:
+    ColorMap1: "ACI-ENT-EVN"
+    ColorMap2: "BGN-PMN-SPT"
+
+    #EXPLANATION OF LDFC CONFIG PARAMETERS
+    # The ColourFilter parameter determines how much the low index values are emphasized or de-emphasized.
+    # The purpose is to make low intensity features stand out (emphasis) or become even less obvious (de-emphasis).
+    # This parameter applies a function that lies between y=x^-2 and y=x^2, i.e. between the square-root and the square.
+    # For an acoustic index value of X, newX = [(1/c - 1) * X^2 + X] * c, where c = the supplied filterCoeff.
+    #    When filterCoeff = 1.0, small values are maximally emphasized, i.e. y=sqrt(x).
+    #    When filterCoeff = 0.0, the matrix remains unchanged, that is, y=x.
+    #    When filterCoeff =-1.0, small values are maximally de-emphasized, i.e. y=x^2.
+    #    Generally usage suggests that a value of -0.25 is suitable. i.e. a slight de-emphasis.
+    ColourFilter: -0.25
+    
+    # minutes x-axis scale
+    XAxisTicIntervalSeconds: 3600
+
+    # Hertz y-axis scale
+    # Only three option work now: "Linear", "Mel"' "Linear125Octaves7Tones28Nyquist32000" work at present
+    # Future options will be: Linear62Octaves31Nyquist11025, Linear125Octaves30Nyquist11025, Octaves24Nyquist32000
+    FreqScale: "Linear"
+    YAxisTicInterval: 1000
 ...
 

--- a/src/AnalysisPrograms/AcousticIndices.cs
+++ b/src/AnalysisPrograms/AcousticIndices.cs
@@ -12,7 +12,6 @@ namespace AnalysisPrograms
 {
     using System;
     using System.Collections.Generic;
-    using System.Data;
     using System.Diagnostics;
     using System.Drawing;
     using System.Drawing.Imaging;
@@ -21,7 +20,6 @@ namespace AnalysisPrograms
     using System.Reflection;
     using Acoustics.Shared;
     using Acoustics.Shared.ConfigFile;
-    using Acoustics.Shared.Contracts;
     using Acoustics.Shared.Csv;
     using AnalysisBase;
     using AnalysisBase.ResultBases;
@@ -33,7 +31,6 @@ namespace AnalysisPrograms
     using AudioAnalysisTools.TileImage;
     using AudioAnalysisTools.WavTools;
     using log4net;
-    using Production;
     using TowseyLibrary;
     using Zio;
 
@@ -75,6 +72,19 @@ namespace AnalysisPrograms
         [Serializable]
         public class AcousticIndicesConfig : IndexCalculateConfig
         {
+            private LdSpectrogramConfig ldfcsConfig = new LdSpectrogramConfig();
+
+            /// <summary>
+            /// Gets or sets the LDFC spectrogram configuration.
+            /// </summary>
+            public LdSpectrogramConfig LdSpectrogramConfig
+            {
+                get => this.ldfcsConfig;
+                protected set => this.ldfcsConfig = value;
+            }
+
+            public bool TileOutput { get; private set; } = false;
+
             public void Validate(TimeSpan defaultIndexCalculationDuration)
             {
                 SpectralIndexValues.CheckExistenceOfSpectralIndexValues(this.IndexProperties);
@@ -106,8 +116,6 @@ namespace AnalysisPrograms
                         + "ICD != 60.0 so the images won'tbe created");
                 }
             }
-
-            public bool TileOutput { get; private set; } = false;
         }
 
         public AnalysisResult2 Analyze<T>(AnalysisSettings analysisSettings, SegmentSettings<T> segmentSettings)
@@ -263,7 +271,7 @@ namespace AnalysisPrograms
             sampleRate = acousticIndicesConfig.ResampleRate ?? sampleRate;
 
             // Gather settings for rendering false color spectrograms
-            var ldSpectrogramConfig = LdSpectrogramConfig.GetDefaultConfig();
+            var ldSpectrogramConfig = acousticIndicesConfig.LdSpectrogramConfig;
 
             string basename = Path.GetFileNameWithoutExtension(sourceAudio.Name);
 

--- a/src/AnalysisPrograms/Sandpit.cs
+++ b/src/AnalysisPrograms/Sandpit.cs
@@ -62,7 +62,7 @@ namespace AnalysisPrograms
                 Log.WriteLine("# Start Time = " + tStart.ToString(CultureInfo.InvariantCulture));
 
                 //AnalyseFrogDataSet();
-                //Audio2CsvOverOneFile();
+                Audio2CsvOverOneFile();
                 //Audio2CsvOverMultipleFiles();
 
                 // used to get files from availae for Black rail and Least Bittern papers.
@@ -80,7 +80,7 @@ namespace AnalysisPrograms
                 //DrawLongDurationSpectrogram();
                 //DrawClusterSequence();
                 //DrawStandardSpectrograms();
-                Test_DrawFourSpectrograms();
+                //Test_DrawFourSpectrograms();
 
                 //ExtractSpectralFeatures();
                 //HerveGlotinMethods();
@@ -326,7 +326,8 @@ namespace AnalysisPrograms
 
             // Test on STANDARD 24-HOUR RECORDING
             string recordingPath = @"C:\Ecoacoustics\WavFiles\LizZnidersic\TasmanIsland2015_Unit2_Mez\SM304256_0+1_20151114_131652.wav";
-            string outputPath = @"C:\Ecoacoustics\Output\Test\Test24HourRecording\TasmanIslandMez\14";
+            //string outputPath = @"C:\Ecoacoustics\Output\Test\Test24HourRecording\TasmanIslandMez\14";
+            string outputPath = @"C:\Ecoacoustics\Output\Test\Test24HourRecording\Delete";
             string configPath = @"C:\Work\GitHub\audio-analysis\src\AnalysisConfigFiles\Towsey.Acoustic.yml";
 
             // Ivan Campos recordings

--- a/src/AudioAnalysisTools/Indices/IndexCalculateConfig.cs
+++ b/src/AudioAnalysisTools/Indices/IndexCalculateConfig.cs
@@ -6,20 +6,16 @@ namespace AudioAnalysisTools.Indices
 {
     using System;
     using Acoustics.Shared.ConfigFile;
-
-    using DSP;
+    using AudioAnalysisTools.DSP;
+    using AudioAnalysisTools.LongDurationSpectrograms;
     using Equ;
-
     using Fasterflect;
-
     using log4net;
-
     using Newtonsoft.Json;
-
     using YamlDotNet.Serialization;
 
     /// <summary>
-    /// CONFIG CLASS FOR the class IndexCalculate.cs
+    /// CONFIG CLASS FOR the class IndexCalculate.cs.
     /// </summary>
     public class IndexCalculateConfig : AnalyzerConfigIndexProperties, IEquatable<IndexCalculateConfig>, ICloneable
     {
@@ -60,7 +56,7 @@ namespace AudioAnalysisTools.Indices
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IndexCalculateConfig"/> class.
-        /// CONSTRUCTOR
+        /// CONSTRUCTOR.
         /// </summary>
         public IndexCalculateConfig()
         {
@@ -84,7 +80,7 @@ namespace AudioAnalysisTools.Indices
         /// <summary>
         /// Gets or sets the Timespan (in seconds) over which summary and spectral indices are calculated
         /// Default=60.0
-        /// Units=seconds
+        /// Units=seconds.
         /// </summary>
         [YamlIgnore]
         [JsonIgnore]
@@ -122,7 +118,7 @@ namespace AudioAnalysisTools.Indices
         /// Ten seconds is considered a minimum interval to obtain a reliable estimate of BG noise.
         /// The  BG noise interval is not extended beyond start or end of recording segment.
         /// Consequently for a 60sec Index calculation duration, the  BG noise is calculated form the 60sec segment only.
-        /// Default=5 seconds
+        /// Default=5 seconds.
         /// </remarks>
         public double BgNoiseNeighborhood { get; set; }
 
@@ -130,26 +126,26 @@ namespace AudioAnalysisTools.Indices
         /// Gets or sets the FrameWidth - the number of samples to use per FFT window.
         /// FrameWidth is used WITHOUT overlap to calculate the spectral indices.
         /// Default value = 512.
-        /// Units=samples
+        /// Units=samples.
         /// </summary>
         public int FrameLength { get; set; }
 
         /// <summary>
         /// Gets or sets the LowFreqBound.
         /// Default value = 1000.
-        /// Units=Herz
+        /// Units=Herz.
         /// </summary>
         public int LowFreqBound { get; set; }
 
         /// <summary>
         /// Gets or sets the MidFreqBound.
         /// Default value = 8000.
-        /// Units=Herz
+        /// Units=Herz.
         /// </summary>
         public int MidFreqBound { get; set; }
 
         /// <summary>
-        /// Gets or sets frequency scale is Linear or OCtave
+        /// Gets or sets frequency scale is Linear or Octave.
         /// </summary>
         public FreqScaleType FrequencyScale
         {
@@ -185,17 +181,18 @@ namespace AudioAnalysisTools.Indices
         /// Gets or sets the number of Mel-scale filter banks to use.
         /// </summary>
         /// <remarks>
-        /// The default, 0, implies no operation
+        /// The default, 0, implies no operation.
         /// </remarks>
         public int MelScale { get; set; }
 
+        /*
         /// <summary>
         /// WARNING: This method does not incorporate all the parameters in the config.yml file.
         /// Only those that are likely to change.
         /// If you want to change a config parameter in the yml file make sure it appears in this method.
         /// </summary>
-        /// <param name="configuration">the Config config</param>
-        /// <param name="writeParameters">default = false</param>
+        /// <param name="configuration">the Config config.</param>
+        /// <param name="writeParameters">default = false.</param>
         [Obsolete("Incorporation of statically typed config should obviate need for this method")]
         public static IndexCalculateConfig GetConfig(Config configuration,  bool writeParameters = false)
         {
@@ -232,6 +229,7 @@ namespace AudioAnalysisTools.Indices
 
             return config;
         }
+        */
 
         public bool Equals(IndexCalculateConfig other)
         {

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramConfig.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramConfig.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LDSpectrogramConfig.cs" company="QutEcoacoustics">
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
@@ -9,19 +9,18 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using Acoustics.Shared;
     using Acoustics.Shared.ConfigFile;
     using Newtonsoft.Json;
     using YamlDotNet.Serialization;
 
     /// <summary>
-    /// CONFIG CLASS FOR the class LDSpectrogramRGB
+    /// CONFIG CLASS FOR the class LDSpectrogramRGB.
     /// </summary>
     public class LdSpectrogramConfig : Config
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LdSpectrogramConfig"/> class.
-        /// CONSTRUCTOR
+        /// CONSTRUCTOR.
         /// </summary>
         public LdSpectrogramConfig()
         {
@@ -37,12 +36,12 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// <summary>
         /// Gets or sets the type of freq scale.
         /// # Eventual options will be: Linear, Mel, Linear62Octaves31Nyquist11025, Linear125Octaves30Nyquist11025, Octaves24Nyquist32000, Linear125Octaves28Nyquist32000
-        /// # Only "Linear", "Linear125Octaves6Tones28Nyquist11025", "Linear125Octaves7Tones28Nyquist32000" work at present
+        /// # Only "Linear", "Linear125Octaves6Tones28Nyquist11025", "Linear125Octaves7Tones28Nyquist32000" work at present.
         /// </summary>
         public string FreqScale { get; set; }
 
         /// <summary>
-        /// Gets or sets parameter to manipulate the colour map and appearance of the false-colour spectrogram
+        /// Gets or sets parameter to manipulate the colour map and appearance of the false-colour spectrogram.
         /// </summary>
         public string ColorMap1 { get; set; }
 
@@ -54,7 +53,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
 
         /// <summary>
         /// Gets or sets value of the colour filter.
-        /// Its value must be less than 1.0. Good value is 0.75
+        /// Its value must be less than 1.0. Good value is 0.75.
         /// </summary>
         public double? ColourFilter { get; set; }
 
@@ -63,7 +62,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// The default assumes one minute spectra i.e. 60 per hour
         /// But as of January 2015, this is not fixed. The user can adjust
         ///  the tic interval to be appropriate to the time scale of the spectrogram.
-        /// May 2017: XAxisTicIntervalSeconds is the new configuration option!
+        /// May 2017: XAxisTicIntervalSeconds is the new configuration option!.
         /// </summary>
         [YamlIgnore]
         [JsonIgnore]
@@ -78,19 +77,19 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// The default assumes one minute spectra i.e. 60 per hour
         /// But as of January 2015, this is not fixed. The user can adjust
         ///  the tic interval to be appropriate to the time scale of the spectrogram.
-        /// May 2017: Now measured in seconds and usage XAxisTicIntervalSeconds is preferred
+        /// May 2017: Now measured in seconds and usage XAxisTicIntervalSeconds is preferred.
         /// </summary>
         public double XAxisTicIntervalSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets YAxisTicInterval in Hertz.
         /// The vertical spacing between horizontal grid lines for the y-Axis
-        /// mark 1 kHz intervals
+        /// mark 1 kHz intervals.
         /// </summary>
         public int YAxisTicInterval { get; set; }
 
         /// <summary>
-        /// In seconds, the horizontal spacing between vertical grid lines for the x-Axis
+        /// In seconds, the horizontal spacing between vertical grid lines for the x-Axis.
         /// </summary>
         public double CalculateYAxisTickInterval(double sampleRate, double frameWidth)
         {
@@ -99,7 +98,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         }
 
         /// <summary>
-        /// READS A YAML CONFIG FILE into a Config variable and then transfers all values into the appropriate config class
+        /// READS A YAML CONFIG FILE into a Config variable and then transfers all values into the appropriate config class.
         /// </summary>
         /// <returns>
         /// The <see cref="LdSpectrogramConfig"/>.
@@ -120,7 +119,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         }
 
         /// <summary>
-        /// Gets a default config for long-duration false-colour spectrograms
+        /// Gets a default config for long-duration false-colour spectrograms.
         /// </summary>
         public static LdSpectrogramConfig GetDefaultConfig(string colourMap1, string colourMap2)
         {

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -69,11 +69,11 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         // string[] keys = { "ACI", "ENT", "EVN", "BGN", "POW", "EVN" }; // the OLD default i.e. since July 2015
         // More recently (2018 onwards) other combinations have been used expecially for the blue channel index.
         // public static readonly string DefaultColorMap1 = "ACI, ENT, EVN";
-        // public static readonly string DefaultColorMap2 = "BGN, PMN, R3D";
+        // public static readonly string DefaultColorMap2 = "BGN, PMN, SPT";
 
         // the defaults
         public static readonly string DefaultColorMap1 = SpectrogramConstants.RGBMap_ACI_ENT_EVN;
-        public static readonly string DefaultColorMap2 = SpectrogramConstants.RGBMap_BGN_PMN_R3D;
+        public static readonly string DefaultColorMap2 = SpectrogramConstants.RGBMap_BGN_PMN_SPT;
 
         public static string[] GetArrayOfAvailableKeys()
         {


### PR DESCRIPTION
This branch consists of three commits.
All tests passed after the third and last commit.
Now able to include LDFC spectrogram properties in the Analysis config file.