### PR TITLE
Ldfc spectrogram color correction issue #274

### DIFF
--- a/src/AnalysisConfigFiles/IndexPropertiesConfig.yml
+++ b/src/AnalysisConfigFiles/IndexPropertiesConfig.yml
@@ -532,7 +532,7 @@ CVR:
   DefaultValue: 0.0
   DoDisplay: true
   NormMin: 0.0
-  NormMax: 0.3
+  NormMax: 0.4
   CalculateNormBounds: false
   ProjectID: Acoustic Indices
   Units: ""

--- a/src/AnalysisConfigFiles/IndexPropertiesConfig.yml
+++ b/src/AnalysisConfigFiles/IndexPropertiesConfig.yml
@@ -532,7 +532,7 @@ CVR:
   DefaultValue: 0.0
   DoDisplay: true
   NormMin: 0.0
-  NormMax: 0.2
+  NormMax: 0.3
   CalculateNormBounds: false
   ProjectID: Acoustic Indices
   Units: ""
@@ -565,7 +565,7 @@ EVN:
   DefaultValue: 0.0
   DoDisplay: true
   NormMin: 0.0
-  NormMax: 2.0
+  NormMax: 4.0
   CalculateNormBounds: false
   ProjectID: Acoustic Indices
   Units: "events/s"

--- a/src/AnalysisConfigFiles/SpectrogramFalseColourConfig.yml
+++ b/src/AnalysisConfigFiles/SpectrogramFalseColourConfig.yml
@@ -4,7 +4,7 @@
 # It should NOT contain dynamic data (like file names or analysis types)
 
 ColorMap1: "ACI-ENT-EVN"
-ColorMap2: "BGN-PMN-R3D"
+ColorMap2: "BGN-PMN-CVR"
 
 # The ColourFilter parameter determines how much the low index values are emphasized or de-emphasized.
 # The purpose is to make low intensity features stand out (emphasis) or become even less obvious (de-emphasis).

--- a/src/AnalysisConfigFiles/SpectrogramFalseColourConfig.yml
+++ b/src/AnalysisConfigFiles/SpectrogramFalseColourConfig.yml
@@ -16,6 +16,13 @@ ColorMap2: "BGN-PMN-CVR"
 #    Generally usage suggests that a value of -0.25 is suitable. i.e. a slight de-emphasis.
 ColourFilter: -0.25
 
+# The third index in the color map is always mapped to blue. The eye is less sensitive to blue and it can be difficult to see in dark background.
+# Therefore we enhance the blue by making it brighter, but only when the red and green values are low.
+# This could be done better but can be a helpful! The intention is to create a more visible light blue color.
+# The default value for BlueEnhanceParameter = 0.0 i.e. do no enhancement.
+# Suggested value is 0.4 when want to enhance visualisation of the "blue" index. 
+BlueEnhanceParameter: 0.4
+
 # minutes x-axis scale
 XAxisTicIntervalSeconds: 3600
 

--- a/src/AnalysisConfigFiles/Towsey.Acoustic.yml
+++ b/src/AnalysisConfigFiles/Towsey.Acoustic.yml
@@ -121,6 +121,13 @@ LdSpectrogramConfig:
     #    When filterCoeff =-1.0, small values are maximally de-emphasized, i.e. y=x^2.
     #    Generally usage suggests that a value of -0.25 is suitable. i.e. a slight de-emphasis.
     ColourFilter: -0.25
+    
+    # The third index in the color map is always mapped to blue. The eye is less sensitive to blue and it can be difficult to see in dark background.
+    # Therefore we enhance the blue by making it brighter, but only when the red and green values are low.
+    # This could be done better but can be a helpful! The intention is to create a more visible light blue color.
+    # The default value for BlueEnhanceParameter = 0.0 i.e. do no enhancement.
+    # Suggested value is 0.4 when want to enhance visualisation of the "blue" index. 
+    BlueEnhanceParameter: 0.4
 
     # minutes x-axis scale
     XAxisTicIntervalSeconds: 3600

--- a/src/AnalysisPrograms/ConcatenateIndexFiles.cs
+++ b/src/AnalysisPrograms/ConcatenateIndexFiles.cs
@@ -3,12 +3,11 @@
 // </copyright>
 
 // Defines the ConcatenateIndexFiles type.
-//
 // Action code for this activity = "concatenateIndexFiles"
+
 // Activity Codes for other tasks to do with spectrograms and audio files:
-//
-// audio2csv - Calls AnalyseLongRecording.Execute(): Outputs acoustic indices and LD false-colour spectrograms.
-// audio2sonogram - Calls AnalysisPrograms.Audio2Sonogram.Main(): Produces a sonogram from an audio file - EITHER custom OR via SOX.Generates multiple spectrogram images and oscilllations info
+// audio2csv - Calls AnalyseLongRecording.Execute(): Outputs acoustic indices and LD false-color spectrograms.
+// audio2sonogram - Calls AnalysisPrograms.Audio2Sonogram.Main(): Produces a sonogram from an audio file - EITHER custom OR via SOX.Generates multiple spectrogram images and oscillations info
 // indicescsv2image - Calls DrawSummaryIndexTracks.Main(): Input csv file of summary indices. Outputs a tracks image.
 // colourspectrogram - Calls DrawLongDurationSpectrograms.Execute():  Produces LD spectrograms from matrices of indices.
 // zoomingspectrograms - Calls DrawZoomingSpectrograms.Execute():  Produces LD spectrograms on different time scales.
@@ -33,15 +32,15 @@ namespace AnalysisPrograms
     using System.Threading.Tasks;
     using Acoustics.Shared;
     using Acoustics.Shared.Csv;
+    using AnalysisPrograms.Production;
+    using AnalysisPrograms.Production.Arguments;
+    using AnalysisPrograms.Production.Validation;
     using AudioAnalysisTools;
     using AudioAnalysisTools.Indices;
     using AudioAnalysisTools.LongDurationSpectrograms;
     using AudioAnalysisTools.StandardSpectrograms;
     using log4net;
     using McMaster.Extensions.CommandLineUtils;
-    using Production;
-    using Production.Arguments;
-    using Production.Validation;
     using TowseyLibrary;
     using Zio;
 
@@ -65,7 +64,7 @@ namespace AnalysisPrograms
                 Description = "One or more directories where the original csv files are located.")]
             public DirectoryInfo[] InputDataDirectories { get; set; }
 
-            [Obsolete("Originally hack to get around powerargs limitation, can probably be removed soon")]
+            [Obsolete("Originally hack to get around power-args limitation, can probably be removed soon")]
             [Option(
                 CommandOptionType.SingleValue,
                 Description = "One directory where the original csv files are located. This option exists as an alternative to input data directories")]
@@ -78,7 +77,7 @@ namespace AnalysisPrograms
             [LegalFilePath]
             public DirectoryInfo OutputDirectory { get; set; }
 
-            [Option(Description = "Used to get the required data.csv files, which are assumed to be in a matching dir or subdirectory. E.g. use name of audio file suffix e.g.: *.wav")]
+            [Option(Description = "Used to get the required data.csv files, which are assumed to be in a matching dir or sub-directory. E.g. use name of audio file suffix e.g.: *.wav")]
             public string DirectoryFilter { get; set; }
 
             [Option(
@@ -104,17 +103,17 @@ namespace AnalysisPrograms
 
             [Option(
                 CommandOptionType.NoValue,
-                Description = "Draw false-colour spectrograms after concatenating index files",
+                Description = "Draw false-color spectrograms after concatenating index files",
                 ShortName = "")]
             public bool DrawImages { get; set; } = true;
 
             [Option(
-                Description = "The mapping of indices to colour channel in false-colour spectrogram 1",
+                Description = "The mapping of indices to color channel in false-color spectrogram 1",
                 ShortName = "")]
             public string ColorMap1 { get; set; }
 
             [Option(
-                Description = "The mapping of indices to colour channel in false-colour spectrogram 2",
+                Description = "The mapping of indices to color channel in false-color spectrogram 2",
                 ShortName = "")]
             public string ColorMap2 { get; set; }
 

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramConfig.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramConfig.cs
@@ -28,6 +28,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             this.ColorMap1 = LDSpectrogramRGB.DefaultColorMap1;
             this.ColorMap2 = LDSpectrogramRGB.DefaultColorMap2;
             this.ColourFilter = SpectrogramConstants.BACKGROUND_FILTER_COEFF;
+            this.BlueEnhanceParameter = 0.0;
             this.XAxisTicInterval = SpectrogramConstants.X_AXIS_TIC_INTERVAL;
             this.FreqScale = "Linear";
             this.YAxisTicInterval = 1000;
@@ -41,21 +42,27 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         public string FreqScale { get; set; }
 
         /// <summary>
-        /// Gets or sets parameter to manipulate the colour map and appearance of the false-colour spectrogram.
+        /// Gets or sets parameter to manipulate the color map and appearance of the false-colour spectrogram.
         /// </summary>
         public string ColorMap1 { get; set; }
 
         /// <summary>
         /// Gets or sets parameter to manipulate the colour map and appearance of the false-colour spectrogram
-        /// Pass two colour maps because two maps convey more information.
+        /// Pass two color maps because two maps convey more information.
         /// </summary>
         public string ColorMap2 { get; set; }
 
         /// <summary>
-        /// Gets or sets value of the colour filter.
+        /// Gets or sets value of the color filter.
         /// Its value must be less than 1.0. Good value is 0.75.
         /// </summary>
         public double? ColourFilter { get; set; }
+
+        /// <summary>
+        /// Gets or sets value of the blue enhancement parameter.
+        /// Its value must be in 0.0 to 1.0. Current suggested value is 0.5.
+        /// </summary>
+        public double? BlueEnhanceParameter { get; set; }
 
         /// <summary>
         /// Gets or sets the default XAxisTicInterval.
@@ -119,13 +126,14 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         }
 
         /// <summary>
-        /// Gets a default config for long-duration false-colour spectrograms.
+        /// Gets a default config for long-duration false-color spectrograms.
+        /// But allows caller to substitute custom color maps.
         /// </summary>
-        public static LdSpectrogramConfig GetDefaultConfig(string colourMap1, string colourMap2)
+        public static LdSpectrogramConfig GetDefaultConfig(string colorMap1, string colorMap2)
         {
             var ldSpectrogramConfig = GetDefaultConfig();
-            ldSpectrogramConfig.ColorMap1 = colourMap1;
-            ldSpectrogramConfig.ColorMap2 = colourMap2;
+            ldSpectrogramConfig.ColorMap1 = colorMap1;
+            ldSpectrogramConfig.ColorMap2 = colorMap2;
             return ldSpectrogramConfig;
         }
 
@@ -164,9 +172,6 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             return keys;
         }
 
-        public string[] GetKeys()
-        {
-            return GetKeys(this.ColorMap1, this.ColorMap2);
-        }
+        public string[] GetKeys() => GetKeys(this.ColorMap1, this.ColorMap2);
     }
 }

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramDistance.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramDistance.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LDSpectrogramDistance.cs" company="QutEcoacoustics">
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
@@ -12,8 +12,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
     using System.IO;
     using Acoustics.Shared;
     using Acoustics.Shared.ConfigFile;
-
-    using Indices;
+    using AudioAnalysisTools.Indices;
     using TowseyLibrary;
 
     public static class LDSpectrogramDistance
@@ -83,19 +82,11 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         ///     It takes as input any number of csv files of acoustic indices in spectrogram columns.
         ///     Typically there will be at least three indices csv files for each of the original recordings to be compared.
         ///     The method produces four spectrogram image files:
-        ///     1) A negative false-colour spectrogram derived from the indices of recording 1.
-        ///     2) A negative false-colour spectrogram derived from the indices of recording 2.
-        ///     3) A spectrogram of euclidean distances bewteen the two input files.
+        ///     1) A negative false-color spectrogram derived from the indices of recording 1.
+        ///     2) A negative false-color spectrogram derived from the indices of recording 2.
+        ///     3) A spectrogram of euclidean distances between the two input files.
         ///     4) The above three spectrograms combined in one image.
         /// </summary>
-        /// <param name="inputDirectory">
-        /// </param>
-        /// <param name="inputFileName1">
-        /// </param>
-        /// <param name="inputFileName2">
-        /// </param>
-        /// <param name="outputDirectory">
-        /// </param>
         public static void DrawDistanceSpectrogram(
             DirectoryInfo inputDirectory,
             FileInfo inputFileName1,
@@ -109,10 +100,9 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             cs1.BackgroundFilter = backgroundFilterCoeff;
             string[] keys = colorMap.Split('-');
             cs1.ReadCsvFiles(inputDirectory, inputFileName1.Name, keys);
+            double blueEnhanceParameter = 0.0;
 
-            // ColourSpectrogram.BlurSpectrogram(cs1);
-            // cs1.DrawGreyScaleSpectrograms(opdir, opFileName1);
-            cs1.DrawNegativeFalseColourSpectrogram(outputDirectory, outputFileName1);
+            cs1.DrawNegativeFalseColorSpectrogram(outputDirectory, outputFileName1, blueEnhanceParameter);
             string imagePath = Path.Combine(outputDirectory.FullName, outputFileName1 + ".COLNEG.png");
             Image spg1Image = ImageTools.ReadImage2Bitmap(imagePath);
             if (spg1Image == null)
@@ -122,11 +112,11 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             }
 
             int nyquist = cs1.SampleRate / 2;
-            int herzInterval = 1000;
+            int hertzInterval = 1000;
 
             string title =
                 string.Format(
-                    "FALSE COLOUR SPECTROGRAM: {0}.      (scale:hours x kHz)       (colour: R-G-B={1})",
+                    "FALSE COLOUR SPECTROGRAM: {0}.      (scale:hours x kHz)       (color: R-G-B={1})",
                     inputFileName1,
                     cs1.ColorMode);
             Image titleBar = LDSpectrogramRGB.DrawTitleBarOfFalseColourSpectrogram(title, spg1Image.Width);
@@ -134,16 +124,19 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                 spg1Image,
                 titleBar,
                 cs1,
-                nyquist, herzInterval);
+                nyquist,
+                hertzInterval);
 
             string outputFileName2 = inputFileName2.Name;
-            var cs2 = new LDSpectrogramRGB(minuteOffset, xScale, sampleRate, frameWidth, colorMap);
-            cs2.ColorMode = colorMap;
-            cs2.BackgroundFilter = backgroundFilterCoeff;
+            var cs2 = new LDSpectrogramRGB(minuteOffset, xScale, sampleRate, frameWidth, colorMap)
+            {
+                ColorMode = colorMap,
+                BackgroundFilter = backgroundFilterCoeff,
+            };
             cs2.ReadCsvFiles(inputDirectory, inputFileName2.Name, keys);
 
             // cs2.DrawGreyScaleSpectrograms(opdir, opFileName2);
-            cs2.DrawNegativeFalseColourSpectrogram(outputDirectory, outputFileName2);
+            cs2.DrawNegativeFalseColorSpectrogram(outputDirectory, outputFileName2, blueEnhanceParameter);
             imagePath = Path.Combine(outputDirectory.FullName, outputFileName2 + ".COLNEG.png");
             Image spg2Image = ImageTools.ReadImage2Bitmap(imagePath);
             if (spg2Image == null)
@@ -161,9 +154,10 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                 spg2Image,
                 titleBar,
                 cs1,
-                nyquist, herzInterval);
+                nyquist,
+                hertzInterval);
 
-            string outputFileName4 = inputFileName1 + ".EuclidianDistance.png";
+            string outputFileName4 = inputFileName1 + ".EuclideanDistance.png";
             Image deltaSp = DrawDistanceSpectrogram(cs1, cs2);
             Color[] colorArray = LDSpectrogramRGB.ColourChart2Array(GetDifferenceColourChart());
             titleBar = DrawTitleBarOfEuclidianDistanceSpectrogram(
@@ -172,7 +166,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                 colorArray,
                 deltaSp.Width,
                 SpectrogramConstants.HEIGHT_OF_TITLE_BAR);
-            deltaSp = LDSpectrogramRGB.FrameLDSpectrogram(deltaSp, titleBar, cs2, nyquist, herzInterval);
+            deltaSp = LDSpectrogramRGB.FrameLDSpectrogram(deltaSp, titleBar, cs2, nyquist, hertzInterval);
             deltaSp.Save(Path.Combine(outputDirectory.FullName, outputFileName4));
 
             string outputFileName5 = inputFileName1 + ".2SpectrogramsAndDistance.png";
@@ -270,7 +264,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                 mode2[2],
                 stDv2[2]);
 
-            // assume all matricies are normalised and of the same dimensions
+            // assume all matrices are normalised and of the same dimensions
             int rows = m1Red.GetLength(0); // number of rows
             int cols = m1Red.GetLength(1); // number
             var d12Matrix = new double[rows, cols];
@@ -303,8 +297,6 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                 }
             }
 
- // rows
-
             double[] array = DataTools.Matrix2Array(d12Matrix);
             double avDist, sdDist;
             NormalDist.AverageAndSD(array, out avDist, out sdDist);
@@ -316,8 +308,6 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                 }
             }
 
-            // int MaxRGBValue = 255;
-            // int v;
             double zScore;
             Dictionary<string, Color> colourChart = GetDifferenceColourChart();
             Color colour;
@@ -436,7 +426,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             int width,
             int height)
         {
-            Image colourChart = ImageTools.DrawColourChart(width, height, colorArray);
+            Image colorChart = ImageTools.DrawColourChart(width, height, colorArray);
 
             var bmp = new Bitmap(width, height);
             Graphics g = Graphics.FromImage(bmp);
@@ -447,7 +437,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             // Font stringFont = new Font("Tahoma", 9);
             var stringSize = new SizeF();
 
-            string text = string.Format("EUCLIDIAN DISTANCE SPECTROGRAM (scale:hours x kHz)");
+            string text = string.Format("EUCLIDEAN DISTANCE SPECTROGRAM (scale:hours x kHz)");
             int X = 4;
             g.DrawString(text, stringFont, Brushes.Wheat, new PointF(X, 3));
 
@@ -458,9 +448,9 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
 
             stringSize = g.MeasureString(text, stringFont);
             X += stringSize.ToSize().Width + 1;
-            g.DrawImage(colourChart, X, 1);
+            g.DrawImage(colorChart, X, 1);
 
-            X += colourChart.Width;
+            X += colorChart.Width;
             text = "-99.9%conf   " + name2;
             g.DrawString(text, stringFont, Brushes.Wheat, new PointF(X, 3));
             stringSize = g.MeasureString(text, stringFont);
@@ -468,10 +458,10 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
 
             text = Meta.OrganizationTag;
             stringSize = g.MeasureString(text, stringFont);
-            int X2 = width - stringSize.ToSize().Width - 2;
-            if (X2 > X)
+            int x2 = width - stringSize.ToSize().Width - 2;
+            if (x2 > X)
             {
-                g.DrawString(text, stringFont, Brushes.Wheat, new PointF(X2, 3));
+                g.DrawString(text, stringFont, Brushes.Wheat, new PointF(x2, 3));
             }
 
             g.DrawLine(new Pen(Color.Gray), 0, 0, width, 0); // draw upper boundary
@@ -482,19 +472,19 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
 
         public static Dictionary<string, Color> GetDifferenceColourChart()
         {
-            var colourChart = new Dictionary<string, Color>();
-            colourChart.Add("+99.9%", Color.FromArgb(255, 190, 20));
-            colourChart.Add("+99.0%", Color.FromArgb(240, 50, 30)); // +99% conf
-            colourChart.Add("+95.0%", Color.FromArgb(200, 30, 15)); // +95% conf
-            colourChart.Add("+NotSig", Color.FromArgb(50, 5, 5)); // + not significant
-            colourChart.Add("NoValue", Color.Black);
+            var colorChart = new Dictionary<string, Color>();
+            colorChart.Add("+99.9%", Color.FromArgb(255, 190, 20));
+            colorChart.Add("+99.0%", Color.FromArgb(240, 50, 30)); // +99% conf
+            colorChart.Add("+95.0%", Color.FromArgb(200, 30, 15)); // +95% conf
+            colorChart.Add("+NotSig", Color.FromArgb(50, 5, 5)); // + not significant
+            colorChart.Add("NoValue", Color.Black);
 
             // no value
-            colourChart.Add("-99.9%", Color.FromArgb(20, 255, 230));
-            colourChart.Add("-99.0%", Color.FromArgb(30, 240, 50)); // +99% conf
-            colourChart.Add("-95.0%", Color.FromArgb(15, 200, 30)); // +95% conf
-            colourChart.Add("-NotSig", Color.FromArgb(10, 50, 20)); // + not significant
-            return colourChart;
+            colorChart.Add("-99.9%", Color.FromArgb(20, 255, 230));
+            colorChart.Add("-99.0%", Color.FromArgb(30, 240, 50)); // +99% conf
+            colorChart.Add("-95.0%", Color.FromArgb(15, 200, 30)); // +95% conf
+            colorChart.Add("-NotSig", Color.FromArgb(10, 50, 20)); // + not significant
+            return colorChart;
         }
-    } // class LDSpectrogramDistance
+    }
 }

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -885,8 +885,8 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// </summary>
         public static Image DrawRgbColorMatrix(double[,] redM, double[,] grnM, double[,] bluM, bool doReverseColor, double blueEnhanceParameter)
         {
-            int rows = redM.GetLength(0); //number of rows
-            int cols = redM.GetLength(1); //number
+            int rows = redM.GetLength(0);
+            int cols = redM.GetLength(1);
             var bmp = new Bitmap(cols, rows, PixelFormat.Format24bppRgb);
 
             for (int row = 0; row < rows; row++)
@@ -905,12 +905,11 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                         b = 0.5;
                     }
 
-                    // Enhance blue color where it is difficult to see on a black background
-                    // There should be a principled way to do this!
-                    // The intention is to create a more visible light blue color.
+                    // Enhance blue color where it is difficult to see on a black background.
+                    // Go for a more visible pale cyan color.
                     if (r < 0.1 && g < 0.1 && b > 0.1 && blueEnhanceParameter > 0.0)
                     {
-                        r += blueEnhanceParameter * (b - r);
+                        r += blueEnhanceParameter * 0.5 * (b - r);
                         g += blueEnhanceParameter * (b - g);
                         b += 0.1;
 
@@ -931,7 +930,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     var v3 = b.ScaleUnitToByte();
                     var color = Color.FromArgb(v1, v2, v3);
                     bmp.SetPixel(column, row, color);
-                } //end all columns
+                }
             }
 
             return bmp;
@@ -944,8 +943,8 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         public static Image DrawFourColorSpectrogram(double[,] redM, double[,] grnM, double[,] bluM, double[,] greM, bool doReverseColor)
         {
             // assume all matrices are normalised and of the same dimensions
-            int rows = redM.GetLength(0); //number of rows
-            int cols = redM.GetLength(1); //number
+            int rows = redM.GetLength(0);
+            int cols = redM.GetLength(1);
 
             var bmp = new Bitmap(cols, rows, PixelFormat.Format24bppRgb);
             int maxRgbValue = 255;

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -3,19 +3,19 @@
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
 // <summary>
-//   This class generates false-colour spectrograms of long duration audio recordings.
+//   This class generates false-color spectrograms of long duration audio recordings.
 //   Important properties are:
-//   1) the colour map which maps three acoutic indices to RGB.
+//   1) the color map which maps three acoustic indices to RGB.
 //   2) The scale of the x and y axes which are determined by the sample rate, frame size etc.
-//   In order to create false colour spectrograms, copy the following method:
-//                                           public static void DrawFalseColourSpectrograms(LDSpectrogramConfig configuration)
+//   In order to create false-color spectrograms, copy the following method:
+//                                           public static void DrawFalseColorSpectrograms(LDSpectrogramConfig configuration)
 //   All the arguments can be passed through a config file.
 //   Create the config file through an instance of the class LDSpectrogramConfig and then call config.WritConfigToYAML(FileInfo path).
 //   Then pass that path to the above static method.
 //
 //  Activity Codes for other tasks to do with spectrograms and audio files:
 //
-// audio2csv - Calls AnalyseLongRecording.Execute(): Outputs acoustic indices and LD false-colour spectrograms.
+// audio2csv - Calls AnalyseLongRecording.Execute(): Outputs acoustic indices and LD false-color spectrograms.
 // audio2sonogram - Calls AnalysisPrograms.Audio2Sonogram.Main(): Produces a sonogram from an audio file - EITHER custom OR via SOX.Generates multiple spectrogram images and oscilllations info
 // indicescsv2image - Calls DrawSummaryIndexTracks.Main(): Input csv file of summary indices. Outputs a tracks image.
 // colourspectrogram - Calls DrawLongDurationSpectrograms.Execute():  Produces LD spectrograms from matrices of indices.
@@ -44,21 +44,21 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
     using System.Reflection;
     using Acoustics.Shared;
     using AnalysisBase.ResultBases;
-    using DSP;
-    using Indices;
+    using AudioAnalysisTools.DSP;
+    using AudioAnalysisTools.Indices;
+    using AudioAnalysisTools.StandardSpectrograms;
     using log4net;
-    using StandardSpectrograms;
     using TowseyLibrary;
 
     /// <summary>
-    /// This class generates false-colour spectrograms of long duration audio recordings.
+    /// This class generates false-color spectrograms of long duration audio recordings.
     /// Important properties are:
-    /// 1) the colour map which maps three acoutic indices to RGB.
-    /// 2) The scale of the x and y axes which are dtermined by the sample rate, frame size etc.
-    /// In order to create false colour spectrograms, copy the method
-    ///         public static void DrawFalseColourSpectrograms(LDSpectrogramConfig configuration)
+    /// 1) the color map which maps three acoustic indices to RGB.
+    /// 2) The scale of the x and y axes which are determined by the sample rate, frame size etc.
+    /// In order to create false color spectrograms, copy the method
+    ///         public static void DrawFalseColorSpectrograms(LDSpectrogramConfig configuration)
     /// All the arguments can be passed through a config file.
-    /// Create the config file throu an instance of the class LDSpectrogramConfig
+    /// Create the config file through an instance of the class LDSpectrogramConfig
     /// and then call config.WritConfigToYAML(FileInfo path).
     /// Then pass that path to the above static method.
     /// </summary>
@@ -81,7 +81,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             // Since May 2017, all the likely available matrices are incorporated into a dictionary. Note the new names for PMN and R3D, previously POW and HPN respectively.
             // Note 1: This default array will be subsequently over-written by the indices in the IndexPropertiesConfig file if one is available.
             // Note 1: RHZ, SPT and CVR are correlated with POW and do not add much. CLS is not particularly useful. Currently using R3D
-            // Decmeber 2018: Now all spectral indices are always used in drawing images
+            // December 2018: Now all spectral indices are always used in drawing images.
             return SpectralIndexValues.Keys;
         }
 
@@ -120,20 +120,20 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// Initializes a new instance of the <see cref="LDSpectrogramRGB"/> class.
         /// CONSTRUCTOR.
         /// </summary>
-        public LDSpectrogramRGB(TimeSpan xScale, int sampleRate, string colourMap)
+        public LDSpectrogramRGB(TimeSpan xScale, int sampleRate, string colorMap)
         {
             this.ColorMode = "NEGATIVE"; // the default
             this.BackgroundFilter = SpectrogramConstants.BACKGROUND_FILTER_COEFF; // default BackgroundFilter value
             this.SampleRate = sampleRate;
 
-            // assume default linear Herz scale
+            // assume default linear Hertz scale
             this.FrameWidth = SpectrogramConstants.FRAME_LENGTH;
             this.FreqScale = new FrequencyScale(nyquist: this.SampleRate / 2, frameSize: this.FrameWidth, hertzGridInterval: 1000);
 
             // set the X and Y axis scales for the spectrograms
             this.XTicInterval = xScale;
             this.SampleRate = sampleRate;
-            this.ColorMap = colourMap;
+            this.ColorMap = colorMap;
             this.StartOffset = SpectrogramConstants.MINUTE_OFFSET;
 
             // IMPORTANT NOTE: If an IndexPropertiesConfig file is available, these default keys are later over-written in the method
@@ -145,21 +145,21 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// <summary>
         /// Initializes a new instance of the <see cref="LDSpectrogramRGB"/> class.
         /// CONSTRUCTOR
-        /// WARNING: Ths will create a linear herz scale spectrogram.
+        /// WARNING: Ths will create a linear Hertz scale spectrogram.
         /// </summary>
         /// <param name="minuteOffset">minute of day at which the spectrogram starts.</param>
         /// <param name="xScale">time scale : pixels per hour.</param>
         /// <param name="sampleRate">recording sample rate which also determines scale of Y-axis.</param>
         /// <param name="frameWidth">frame size - which also determines scale of Y-axis.</param>
-        /// <param name="colourMap">acoustic indices used to assign  the three colour mapping.</param>
-        public LDSpectrogramRGB(TimeSpan minuteOffset, TimeSpan xScale, int sampleRate, int frameWidth, string colourMap)
-            : this(xScale, sampleRate, colourMap)
+        /// <param name="colorMap">acoustic indices used to assign  the three color mapping.</param>
+        public LDSpectrogramRGB(TimeSpan minuteOffset, TimeSpan xScale, int sampleRate, int frameWidth, string colorMap)
+            : this(xScale, sampleRate, colorMap)
         {
             this.StartOffset = minuteOffset;
             this.FrameWidth = frameWidth;
         }
 
-        public LDSpectrogramRGB(LdSpectrogramConfig config, IndexGenerationData indexGenerationData, string colourMap)
+        public LDSpectrogramRGB(LdSpectrogramConfig config, IndexGenerationData indexGenerationData, string colorMap)
         {
             this.SampleRate = indexGenerationData.SampleRateResampled;
             this.FrameWidth = indexGenerationData.FrameLength;
@@ -176,7 +176,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             this.IndexCalculationDuration = indexGenerationData.IndexCalculationDuration;
             this.XTicInterval = config.XAxisTicInterval;
 
-            // the Herz scale
+            // the Hertz scale
             int nyquist = indexGenerationData.SampleRateResampled / 2;
             int yAxisTicInterval = config.YAxisTicInterval;
 
@@ -218,7 +218,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             }
 
             this.ColorMode = "NEGATIVE"; // the default
-            this.ColorMap = colourMap;
+            this.ColorMap = colorMap;
         }
 
         public string[] SpectrogramKeys { get; private set; }
@@ -238,12 +238,12 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         public double? Longitude { get; set; }
 
         /// <summary>
-        /// Gets or sets the time at which the current LDspectrogram starts.
+        /// Gets or sets the time at which the current LDFC spectrogram starts.
         /// </summary>
         public TimeSpan StartOffset { get; set; }
 
         /// <summary>
-        /// Gets or sets the temporal duration of one subsegment interval for which indices are calculated.
+        /// Gets or sets the temporal duration of one sub-segment interval for which indices are calculated.
         /// </summary>
         public TimeSpan IndexCalculationDuration { get; set; }
 
@@ -284,7 +284,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         public string ColorMap { get; set; }
 
         /// <summary>
-        /// Gets or sets pOSITIVE or NEGATIVE.
+        /// Gets or sets POSITIVE or NEGATIVE.
         /// </summary>
         public string ColorMode { get; set; }
 
@@ -497,7 +497,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     }
 
                     // NOW CALCULATE THE MAX BOUND
-                    stats.GetValueOfNthPercentile(IndexDistributions.UpperPercentileDefault, out int binId, out maxBound);
+                    stats.GetValueOfNthPercentile(IndexDistributions.UpperPercentileDefault, out int _, out maxBound);
 
                     // correct for case where max bound = zero. This can happen where ICD is very short i.e. 0.1s.
                     if (maxBound < 0.0001)
@@ -604,12 +604,12 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             return returnImage;
         }
 
-        public void DrawNegativeFalseColourSpectrogram(DirectoryInfo outputDirectory, string outputFileName)
+        public void DrawNegativeFalseColorSpectrogram(DirectoryInfo outputDirectory, string outputFileName, double blueEnhanceParameter)
         {
-            var bmpNeg = this.DrawFalseColourSpectrogramChromeless("NEGATIVE", this.ColorMap);
+            var bmpNeg = this.DrawFalseColorSpectrogramChromeless("NEGATIVE", this.ColorMap, blueEnhanceParameter);
             if (bmpNeg == null)
             {
-                LoggedConsole.WriteLine("WARNING: From method ColourSpectrogram.DrawNegativeFalseColourSpectrograms()");
+                LoggedConsole.WriteLine("WARNING: From method ColorSpectrogram.DrawNegativeFalseColorSpectrograms()");
                 LoggedConsole.WriteLine("         Null image returned");
                 return;
             }
@@ -634,24 +634,24 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// Chromeless means WITHOUT all the trimmings, such as title bar axis labels, grid lines etc.
         /// However it does add in notated error segments.
         /// </summary>
-        public Image DrawFalseColourSpectrogramChromeless(string colorMode, string colorMap)
+        public Image DrawFalseColorSpectrogramChromeless(string colorMode, string colorMap, double blueEnhanceParameter)
         {
             if (!this.ContainsMatrixForKeys(colorMap))
             {
-                LoggedConsole.WriteLine("WARNING: From method ColourSpectrogram.DrawFalseColourSpectrogram()");
-                LoggedConsole.WriteLine("         No matrices are available for the passed colour map.");
+                LoggedConsole.WriteLine("WARNING: From method ColourSpectrogram.DrawFalseColorSpectrogram()");
+                LoggedConsole.WriteLine("         No matrices are available for the passed color map.");
                 return null;
             }
 
             string[] rgbMap = colorMap.Split('-');
 
-            // NormaliseMatrixValues spectrogram values and de-emphasize the low background values
+            // NormalizeMatrixValues spectrogram values and de-emphasize the low background values
             var redMatrix = this.GetNormalisedSpectrogramMatrix(rgbMap[0]);
             var grnMatrix = this.GetNormalisedSpectrogramMatrix(rgbMap[1]);
             var bluMatrix = this.GetNormalisedSpectrogramMatrix(rgbMap[2]);
-            bool doReverseColour = colorMode.StartsWith("POS");
+            bool doReverseColor = colorMode.StartsWith("POS");
 
-            var bmp = DrawRgbColourMatrix(redMatrix, grnMatrix, bluMatrix, doReverseColour);
+            var bmp = DrawRgbColorMatrix(redMatrix, grnMatrix, bluMatrix, doReverseColor, blueEnhanceParameter);
 
             if (bmp == null)
             {
@@ -692,7 +692,8 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             matrix2 = this.GetNormalisedSpectrogramMatrix(rgbMap2[2]);
             var bluMatrix = MatrixTools.AddMatricesWeightedSum(matrix1, blendWt1, matrix2, blendWt2);
 
-            var bmp = DrawRgbColourMatrix(redMatrix, grnMatrix, bluMatrix, false);
+            var blueEnhanceParameter = 0.0;
+            var bmp = DrawRgbColorMatrix(redMatrix, grnMatrix, bluMatrix, false, blueEnhanceParameter);
             return bmp;
         }
 
@@ -787,12 +788,12 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         }
 
         /// <summary>
-        /// Frames a false-colourspectrogram.
+        /// Frames a false-color spectrogram.
         /// Creates the title bar and the time scale. Also adds frequency grid lines to the image.
-        /// Note that the 'nyquist' and 'hertzGridInterval' arguments are used ONLY if the cs.Freqscale field==null.
+        /// Note that the 'nyquist' and 'hertzGridInterval' arguments are used ONLY if the cs.FreqScale field==null.
         /// Also note that in this case, the frequency scale will be linear.
         /// </summary>
-        public static Image FrameLDSpectrogram(Image bmp1, Image titleBar, LDSpectrogramRGB cs, int nyquist, int herzInterval)
+        public static Image FrameLDSpectrogram(Image bmp1, Image titleBar, LDSpectrogramRGB cs, int nyquist, int hertzInterval)
         {
             var xAxisPixelDuration = cs.IndexCalculationDuration;
             var fullDuration = TimeSpan.FromTicks(xAxisPixelDuration.Ticks * bmp1.Width);
@@ -803,7 +804,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             DateTimeOffset? dateTimeOffset = cs.RecordingStartDate;
             if (dateTimeOffset.HasValue)
             {
-                // draw extra time scale with absolute start time. AND THEN Do SOMETHING WITH IT.
+                // draw extra time scale with absolute start time. AND THEN DO SOMETHING WITH IT.
                 timeBmp2 = ImageTrack.DrawTimeTrack(fullDuration, cs.RecordingStartDate, bmp1.Width, trackHeight);
             }
 
@@ -811,7 +812,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             {
                 // WARNING: The following will create a linear frequency scale.
                 int frameSize = bmp1.Height;
-                var freqScale = new FrequencyScale(nyquist, frameSize, herzInterval);
+                var freqScale = new FrequencyScale(nyquist, frameSize, hertzInterval);
                 cs.FreqScale = freqScale;
             }
 
@@ -845,8 +846,6 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             }
 
             g.DrawLine(new Pen(Color.Gray), 0, 0, width, 0); //draw upper boundary
-
-            // g.DrawLine(pen, duration + 1, 0, trackWidth, 0);
             return bmp;
         }
 
@@ -866,11 +865,6 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             x += stringSize.ToSize().Width + 300;
 
             //g.DrawString(text, stringFont, Brushes.Wheat, new PointF(X, 3));
-
-            // Draw colour chart on title bar. Discontinued this because not helpful.
-            //var colourChart = LDSpectrogramRGB.DrawColourScale(width, SpectrogramConstants.HEIGHT_OF_TITLE_BAR - 2);
-            //g.DrawImage(colourChart, X, 1);
-
             var text = $"SCALE:(time x kHz)        {Meta.OrganizationTag}";
             stringSize = g.MeasureString(text, stringFont);
             int x2 = width - stringSize.ToSize().Width - 2;
@@ -886,12 +880,12 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
 
         /// <summary>
         /// This method assumes that all the passed matrices are normalised and of the same dimensions.
-        /// The method implements a hack to enhance the blue colour because the human eye is less sensitive to blue.
+        /// The method implements a hack to enhance the blue color because the human eye is less sensitive to blue.
         /// If there is a problem with one or more of the three rgb values, a gray pixel is substituted not a black pixel.
-        /// Black is a frequent colour in LDFC spectrograms, but gray is highly unlikely,
+        /// Black is a frequent color in LDFC spectrograms, but gray is highly unlikely,
         /// and therefore its presence stands out as indicating an error in one or more of the rgb values.
         /// </summary>
-        public static Image DrawRgbColourMatrix(double[,] redM, double[,] grnM, double[,] bluM, bool doReverseColour)
+        public static Image DrawRgbColorMatrix(double[,] redM, double[,] grnM, double[,] bluM, bool doReverseColor, double blueEnhanceParameter)
         {
             int rows = redM.GetLength(0); //number of rows
             int cols = redM.GetLength(1); //number
@@ -913,13 +907,13 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                         b = 0.5;
                     }
 
-                    // enhance blue color - it is difficult to see on a black background
+                    // Enhance blue color where it is difficult to see on a black background
                     // There should be a principled way to do this!
                     // The intention is to create a more visible light blue color.
-                    if (r < 0.1 && g < 0.1 && b > 0.1)
+                    if (r < 0.1 && g < 0.1 && b > 0.1 && blueEnhanceParameter > 0.0)
                     {
-                        r += 0.5 * (b - r);
-                        g += 0.5 * (b - g);
+                        r += blueEnhanceParameter * (b - r);
+                        g += blueEnhanceParameter * (b - g);
                         b += 0.1;
 
                         // check for values over 1.0
@@ -927,7 +921,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                         b = Math.Min(1.0, b);
                     }
 
-                    if (doReverseColour)
+                    if (doReverseColor)
                     {
                         r = 1 - r;
                         g = 1 - g;
@@ -949,7 +943,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         /// A technique to derive a spectrogram from four different indices
         /// same as above method but multiply index value by the amplitude value instead of squaring the value.
         /// </summary>
-        public static Image DrawFourColourSpectrogram(double[,] redM, double[,] grnM, double[,] bluM, double[,] greM, bool doReverseColour)
+        public static Image DrawFourColorSpectrogram(double[,] redM, double[,] grnM, double[,] bluM, double[,] greM, bool doReverseColor)
         {
             // assume all matrices are normalised and of the same dimensions
             int rows = redM.GetLength(0); //number of rows
@@ -967,7 +961,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     var d1 = redM[row, column] * gv;
                     var d2 = grnM[row, column] * gv;
                     var d3 = bluM[row, column] * gv;
-                    if (doReverseColour)
+                    if (doReverseColor)
                     {
                         d1 = 1 - d1;
                         d2 = 1 - d2;
@@ -977,8 +971,8 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     var v1 = Convert.ToInt32(Math.Max(0, d1 * maxRgbValue));
                     var v2 = Convert.ToInt32(Math.Max(0, d2 * maxRgbValue));
                     var v3 = Convert.ToInt32(Math.Max(0, d3 * maxRgbValue));
-                    Color colour = Color.FromArgb(v1, v2, v3);
-                    bmp.SetPixel(column, row, colour);
+                    var color = Color.FromArgb(v1, v2, v3);
+                    bmp.SetPixel(column, row, color);
                 }
             }
 
@@ -1001,8 +995,8 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         }
 
         /// <summary>
-        /// Returns an image of an array of colour patches.
-        /// It shows the three primary colours and pairwise combinations.
+        /// Returns an image of an array of color patches.
+        /// It shows the three primary colors and pairwise combinations.
         /// </summary>
         public static Image DrawColourScale(int maxScaleLength, int ht)
         {
@@ -1104,11 +1098,12 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
         {
             var config = ldSpectrogramConfig;
 
-            // These parameters manipulate the colour map and appearance of the false-colour spectrogram
+            // These parameters manipulate the color map and appearance of the false-color spectrogram
             string colorMap1 = config.ColorMap1 ?? DefaultColorMap1;   // assigns indices to RGB
             string colorMap2 = config.ColorMap2 ?? DefaultColorMap2;   // assigns indices to RGB
+            var blueEnhanceParameter = config.BlueEnhanceParameter ?? 0.0;
 
-            // Set ColourFilter: Must lie between +/-1. A good value is -0.25
+            // Set ColorFilter: Must lie between +/-1. A good value is -0.25
             if (config.ColourFilter == null)
             {
                 config.ColourFilter = SpectrogramConstants.BACKGROUND_FILTER_COEFF;
@@ -1137,9 +1132,6 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     cs1.StartOffset = dto.TimeOfDay + cs1.StartOffset;
                 }
             }
-
-            // following line is debug purposes only
-            //cs.StartOffset = cs.StartOffset + TimeSpan.FromMinutes(15);
 
             // Get and set the dictionary of index properties
             Dictionary<string, IndexProperties> dictIp = IndexProperties.GetIndexProperties(indexPropertiesConfigPath);
@@ -1189,21 +1181,11 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             cs1.IndexStats = indexStatistics;
 
             // draw gray scale spectrogram for each index.
-            //string[] keys = colorMap1.Split('-');
-            //cs1.DrawGreyScaleSpectrograms(outputDirectory, fileStem, keys);
-            //keys = colorMap2.Split('-');
-            // draw all available gray scale index spectrograms.
             var keys = SpectralIndexValues.Keys;
             cs1.DrawGreyScaleSpectrograms(outputDirectory, fileStem, keys);
 
-            //    //string[] keys = this.SpectrogramKeys;
-            //cs1.DrawGreyScaleSpectrograms(outputDirectory, fileStem, keys);
-            //}
-            //keys = colorMap2.Split('-');
-            //cs1.DrawGreyScaleSpectrograms(outputDirectory, fileStem, keys);
-
-            // create and save first false-colour spectrogram image
-            var image1NoChrome = cs1.DrawFalseColourSpectrogramChromeless(cs1.ColorMode, colorMap1);
+            // create and save first false-color spectrogram image
+            var image1NoChrome = cs1.DrawFalseColorSpectrogramChromeless(cs1.ColorMode, colorMap1, blueEnhanceParameter);
             Image image1 = null;
             if (image1NoChrome == null)
             {
@@ -1216,8 +1198,8 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                 image1.Save(outputPath1);
             }
 
-            // create and save second false-colour spectrogram image
-            var image2NoChrome = cs1.DrawFalseColourSpectrogramChromeless(cs1.ColorMode, colorMap2);
+            // create and save second false-color spectrogram image
+            var image2NoChrome = cs1.DrawFalseColorSpectrogramChromeless(cs1.ColorMode, colorMap2, blueEnhanceParameter);
             Image image2 = null;
             if (image2NoChrome == null)
             {

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -920,7 +920,7 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     {
                         r += 0.5 * (b - r);
                         g += 0.5 * (b - g);
-                        b += 0.2;
+                        b += 0.1;
 
                         // check for values over 1.0
                         //g = Math.Min(1.0, g);

--- a/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
+++ b/src/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGB.cs
@@ -897,8 +897,6 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
             int cols = redM.GetLength(1); //number
             var bmp = new Bitmap(cols, rows, PixelFormat.Format24bppRgb);
 
-            //const int maxRgbValue = 255;
-
             for (int row = 0; row < rows; row++)
             {
                 for (int column = 0; column < cols; column++)
@@ -916,15 +914,16 @@ namespace AudioAnalysisTools.LongDurationSpectrograms
                     }
 
                     // enhance blue color - it is difficult to see on a black background
-                    // This is a hack - there should be a principled way to do this!
-                    // The effect is to create a more visible cyan colour.
+                    // There should be a principled way to do this!
+                    // The intention is to create a more visible light blue color.
                     if (r < 0.1 && g < 0.1 && b > 0.1)
                     {
-                        g += 0.7 * b;
+                        r += 0.5 * (b - r);
+                        g += 0.5 * (b - g);
                         b += 0.2;
 
                         // check for values over 1.0
-                        g = Math.Min(1.0, g);
+                        //g = Math.Min(1.0, g);
                         b = Math.Min(1.0, b);
                     }
 

--- a/tests/Acoustics.Test/AnalysisPrograms/Concatenation/ConcatenationTests.cs
+++ b/tests/Acoustics.Test/AnalysisPrograms/Concatenation/ConcatenationTests.cs
@@ -161,7 +161,7 @@ namespace Acoustics.Test.AnalysisPrograms.Concatenation
             // we expect only the second half (past midnight) of the image to be rendered
             Assert.That.ImageIsSize(512, 632, actualImage);
             Assert.That.PixelIsColor(new Point(105, 154), Color.FromArgb(34, 30, 126), actualImage);
-            Assert.That.PixelIsColor(new Point(100, 160), Color.FromArgb(15, 28, 64), actualImage);
+            Assert.That.PixelIsColor(new Point(100, 160), Color.FromArgb(8, 28, 64), actualImage);
         }
 
         /// <summary>

--- a/tests/Acoustics.Test/AnalysisPrograms/Concatenation/ConcatenationTests.cs
+++ b/tests/Acoustics.Test/AnalysisPrograms/Concatenation/ConcatenationTests.cs
@@ -78,7 +78,7 @@ namespace Acoustics.Test.AnalysisPrograms.Concatenation
                 IndexPropertiesConfig = indexPropertiesConfig.FullName,
                 FalseColourSpectrogramConfig = testConfig.FullName,
                 ColorMap1 = LDSpectrogramRGB.DefaultColorMap1,
-                ColorMap2 = "BGN-PMN-EVN", // POW was deprecated post May 2017
+                ColorMap2 = "BGN-PMN-EVN",
                 ConcatenateEverythingYouCanLayYourHandsOn = true, // join everything found
                 TimeSpanOffsetHint = TimeSpan.FromHours(8),
                 DrawImages = true,
@@ -104,7 +104,7 @@ namespace Acoustics.Test.AnalysisPrograms.Concatenation
             var actualImage = ImageTools.ReadImage2Bitmap(imageFileInfo.FullName);
             Assert.That.ImageIsSize(722, 632, actualImage);
             Assert.That.PixelIsColor(new Point(100, 100), Color.FromArgb(211, 211, 211), actualImage);
-            Assert.That.PixelIsColor(new Point(200, 125), Color.FromArgb(60, 44, 255), actualImage);
+            Assert.That.PixelIsColor(new Point(200, 125), Color.FromArgb(60, 44, 203), actualImage);
             Assert.That.PixelIsColor(new Point(675, 600), Color.FromArgb(255, 105, 180), actualImage);
         }
 
@@ -133,7 +133,7 @@ namespace Acoustics.Test.AnalysisPrograms.Concatenation
                 IndexPropertiesConfig = indexPropertiesConfig.FullName,
                 FalseColourSpectrogramConfig = testConfig.FullName,
                 ColorMap1 = LDSpectrogramRGB.DefaultColorMap1,
-                ColorMap2 = "BGN-PMN-EVN", // POW was depracated post May 2017
+                ColorMap2 = "BGN-PMN-EVN",
                 ConcatenateEverythingYouCanLayYourHandsOn = false, // 24 hour blocks only
                 TimeSpanOffsetHint = TimeSpan.FromHours(8),
                 DrawImages = true,
@@ -160,8 +160,8 @@ namespace Acoustics.Test.AnalysisPrograms.Concatenation
 
             // we expect only the second half (past midnight) of the image to be rendered
             Assert.That.ImageIsSize(512, 632, actualImage);
-            Assert.That.PixelIsColor(new Point(105, 154), Color.FromArgb(34, 30, 255), actualImage);
-            Assert.That.PixelIsColor(new Point(100, 160), Color.FromArgb(0, 79, 132), actualImage);
+            Assert.That.PixelIsColor(new Point(105, 154), Color.FromArgb(34, 30, 126), actualImage);
+            Assert.That.PixelIsColor(new Point(100, 160), Color.FromArgb(15, 28, 64), actualImage);
         }
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace Acoustics.Test.AnalysisPrograms.Concatenation
                 IndexPropertiesConfig = indexPropertiesConfig.FullName,
                 FalseColourSpectrogramConfig = testConfig.FullName,
                 ColorMap1 = LDSpectrogramRGB.DefaultColorMap1,
-                ColorMap2 = "BGN-PMN-EVN", // POW was depracated post May 2017
+                ColorMap2 = "BGN-PMN-EVN",
                 ConcatenateEverythingYouCanLayYourHandsOn = false, // 24 hour blocks only
                 TimeSpanOffsetHint = TimeSpan.FromHours(8),
                 DrawImages = true,
@@ -217,7 +217,7 @@ namespace Acoustics.Test.AnalysisPrograms.Concatenation
             var actualImage1 = ImageTools.ReadImage2Bitmap(image1FileInfo.FullName);
             Assert.That.ImageIsSize(210, 632, actualImage1);
             Assert.That.PixelIsColor(new Point(100, 100), Color.FromArgb(211, 211, 211), actualImage1);
-            Assert.That.PixelIsColor(new Point(50, 50), Color.FromArgb(86, 27, 16), actualImage1);
+            Assert.That.PixelIsColor(new Point(50, 50), Color.FromArgb(86, 27, 8), actualImage1);
 
             // IMAGE 2: Compare image files - check that image exists and dimensions are correct
             var dateString2 = "20160726";

--- a/tests/Acoustics.Test/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGBTests.cs
+++ b/tests/Acoustics.Test/AudioAnalysisTools/LongDurationSpectrograms/LDSpectrogramRGBTests.cs
@@ -96,7 +96,8 @@ namespace Acoustics.Test.AudioAnalysisTools.LongDurationSpectrograms
             grnM[3, 3] = 0.01;
             bluM[3, 3] = 0.11;
 
-            var image = (Bitmap)LDSpectrogramRGB.DrawRgbColourMatrix(redM, grnM, bluM, doReverseColour: true);
+            var blueEnhanceParameter = 0.0;
+            var image = (Bitmap)LDSpectrogramRGB.DrawRgbColorMatrix(redM, grnM, bluM, doReverseColor: true, blueEnhanceParameter);
 
             Assert.That.PixelIsColor(new Point(1, 1), Color.FromArgb(128, 128, 128), image);
             Assert.That.PixelIsColor(new Point(2, 2), Color.FromArgb(128, 128, 128), image);
@@ -104,15 +105,6 @@ namespace Acoustics.Test.AudioAnalysisTools.LongDurationSpectrograms
             // empty values are rendered as white because of `doReverseColour`
             Assert.That.ImageRegionIsColor(Rectangle.FromLTRB(0,0, 1,5), Color.FromArgb(255, 255, 255), image);
             Assert.That.ImageRegionIsColor(Rectangle.FromLTRB(4,0, 5,5), Color.FromArgb(255, 255, 255), image);
-
-            // To intensify the blue, this method adds 0.7 * d3 to the green value;
-            // and it adds 0.2 to the blue value;
-            // The effect is to create a more visible cyan color.
-            int r = (1 - redM[3, 3]).ScaleUnitToByte();
-            int g = (1 - (grnM[3, 3] + (0.7 * bluM[3, 3]))).ScaleUnitToByte();
-            int b = (1 - (bluM[3, 3] + 0.2)).ScaleUnitToByte();
-            var cyanColor = Color.FromArgb(r, g, b);
-            Assert.That.PixelIsColor(new Point(3, 3), cyanColor, image);
         }
     }
 }

--- a/tests/Acoustics.Test/TestHelpers/ImageAssert.cs
+++ b/tests/Acoustics.Test/TestHelpers/ImageAssert.cs
@@ -40,7 +40,7 @@ namespace Acoustics.Test.TestHelpers
 
         /// <summary>
         /// Check whether a region in an image matches an expected color.
-        /// Does a simplisitic average on each color channel and includes and inbuilt tolerance parameter.
+        /// Does a simplistic average on each color channel and includes and inbuilt tolerance parameter.
         /// A repeating pattern can fool this test.
         /// </summary>
         /// <example>
@@ -103,10 +103,6 @@ namespace Acoustics.Test.TestHelpers
         ///            };
         /// ImageAssert.ImageRegionHasColors(new Rectangle(0, 24, 210, 3),  expectedColors, actualImage1, 0.07);
         /// </example>
-        /// <param name="region"></param>
-        /// <param name="expectedColors"></param>
-        /// <param name="actualImage"></param>
-        /// <param name="tolerance"></param>
         public static void ImageRegionHasColors(
             this Assert assert,
             System.Drawing.Rectangle region,
@@ -200,7 +196,7 @@ namespace Acoustics.Test.TestHelpers
 
         public static void ImageRegionIsColor(this Assert assert, SixLabors.Primitives.Rectangle region, Rgb24 expectedColor, Image<Rgb24> actualImage, double tolerance = 0.0)
         {
-            var width = region.Width;
+            //var width = region.Width;
             var area = region.Width * region.Height;
 
             var red = new int[area];


### PR DESCRIPTION
I have adjusted rendering of indices in blue ie CVR and EVN. I have also changed the colour correction for blue. This has broken unit tests involving ldfc spectrograms but can be easily fixed. Main issue is can you check the adjusted colours of ldfc spectrograms, especially the one which had insect track with a cyan halo around blue. 

Closes #274 