### PR TITLE
Process extension

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,41 +2,58 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/src/AnalysisPrograms/AnalysisPrograms.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
+          "label": "build",
+          "command": "dotnet",
+          "type": "process",
+          "args": [
+            "build",
+            "${workspaceFolder}/src/AnalysisPrograms/AnalysisPrograms.csproj",
+            "/property:GenerateFullPaths=true",
+            "/consoleloggerparameters:NoSummary"
+          ],
+          "problemMatcher": "$msCompile",
+          "group": {
+            "kind": "build",
+            "isDefault": true
+          }
         },
         {
-            "label": "publish",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "publish",
-                "${workspaceFolder}/src/AnalysisPrograms/AnalysisPrograms.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
+          "label": "test",
+          "command": "dotnet",
+          "type": "process",
+          "args": [
+            "test"
+          ],
+          "problemMatcher": "$msCompile",
+          "group": {
+            "kind": "test",
+            "isDefault": true
+          }
         },
         {
-            "label": "watch",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "watch",
-                "run",
-                "${workspaceFolder}/src/AnalysisPrograms/AnalysisPrograms.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
+          "label": "publish",
+          "command": "dotnet",
+          "type": "process",
+          "args": [
+            "publish",
+            "${workspaceFolder}/src/AnalysisPrograms/AnalysisPrograms.csproj",
+            "/property:GenerateFullPaths=true",
+            "/consoleloggerparameters:NoSummary"
+          ],
+          "problemMatcher": "$msCompile"
+        },
+        {
+          "label": "watch",
+          "command": "dotnet",
+          "type": "process",
+          "args": [
+            "watch",
+            "run",
+            "${workspaceFolder}/src/AnalysisPrograms/AnalysisPrograms.csproj",
+            "/property:GenerateFullPaths=true",
+            "/consoleloggerparameters:NoSummary"
+          ],
+          "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/src/Acoustics.Shared/Extensions/ExtensionsGeneral.cs
+++ b/src/Acoustics.Shared/Extensions/ExtensionsGeneral.cs
@@ -1,5 +1,5 @@
 // --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ExtensionsSystem.cs" company="QutEcoacoustics">
+// <copyright file="ExtensionsGeneral.cs" company="QutEcoacoustics">
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
 // <summary>
@@ -9,27 +9,30 @@
 
 namespace System
 {
-    using Collections.Generic;
-    using Collections.Specialized;
-    using ComponentModel;
-    using Diagnostics;
-    using IO;
-    using Linq;
-    using Linq.Expressions;
-    using Runtime.InteropServices;
-    using Runtime.Serialization;
-    using Runtime.Serialization.Formatters.Binary;
-    using Text;
-    using Text.RegularExpressions;
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.ComponentModel;
+    using System.IO;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Runtime.Serialization;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Text;
+    using System.Text.RegularExpressions;
 
     public static class ExtensionsGeneral
     {
-        /// <summary>Deserialise byte array to object.
+        /// <summary>
+        /// Gets ExecutingDirectory.
+        /// </summary>
+        public static string ExecutingDirectory => Path.GetDirectoryName(Reflection.Assembly.GetExecutingAssembly().Location);
+
+        /// <summary>Deserialize byte array to object.
         /// </summary>
         /// <param name="bytes">
         /// The bytes.
         /// </param>
-        /// <returns>Deserialised object.
+        /// <returns>Deserialized object.
         /// </returns>
         public static object BinaryDeserialize(this byte[] bytes)
         {
@@ -46,7 +49,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deserialise byte array to object.
+        /// Deserialize byte array to object.
         /// </summary>
         /// <param name="bytes">
         /// The bytes.
@@ -55,7 +58,7 @@ namespace System
         /// The binder.
         /// </param>
         /// <returns>
-        /// Deserialised object.
+        /// Deserialized object.
         /// </returns>
         public static object BinaryDeserialize(this byte[] bytes, SerializationBinder binder)
         {
@@ -65,7 +68,6 @@ namespace System
             }
 
             var formatter = new BinaryFormatter { Binder = binder };
-
             using (var stream = new MemoryStream(bytes))
             {
                 return formatter.Deserialize(stream);
@@ -73,12 +75,12 @@ namespace System
         }
 
         /// <summary>
-        /// Convert an object to it's binary serialised form.
+        /// Convert an object to it's binary serialized form.
         /// </summary>
         /// <param name="o">
-        /// Object to serialise.
+        /// Object to serialize.
         /// </param>
-        /// <returns>Serialised object.
+        /// <returns>Serialized object.
         /// </returns>
         public static byte[] BinarySerialize(this object o)
         {
@@ -220,11 +222,6 @@ namespace System
         }
 
         /// <summary>
-        /// Gets ExecutingDirectory.
-        /// </summary>
-        public static string ExecutingDirectory => Path.GetDirectoryName(Reflection.Assembly.GetExecutingAssembly().Location);
-
-        /// <summary>
         /// Check if a dictionary has a value for a key.
         /// </summary>
         /// <param name="dictionary">
@@ -310,20 +307,20 @@ namespace System
         /// <param name="source">IQueryable to page.</param>
         /// <param name="page">Page number (begins at 1).</param>
         /// <param name="pageSize">Number of items per page.</param>
-        /// <returns></returns>
+        /// <returns>Paged LINQ to SQL.</returns>
         public static IQueryable<TSource> Page<TSource>(this IQueryable<TSource> source, int page, int pageSize)
         {
             return source.Skip((page - 1) * pageSize).Take(pageSize);
         }
 
         /// <summary>
-        /// Paging for LINQ
+        /// Paging for LINQ.
         /// </summary>
         /// <typeparam name="TSource">IEnumerable of 'object type' to page.</typeparam>
         /// <param name="source">IEnumerable to page.</param>
         /// <param name="page">Page number (begins at 1).</param>
         /// <param name="pageSize">Number of items per page.</param>
-        /// <returns></returns>
+        /// <returns>Paged LINQ.</returns>
         public static IEnumerable<TSource> Page<TSource>(this IEnumerable<TSource> source, int page, int pageSize)
         {
             return source.Skip((page - 1) * pageSize).Take(pageSize);
@@ -336,7 +333,7 @@ namespace System
         /// <param name="value">IQueryable to page.</param>
         /// <param name="startIndex">Index of first item to return.</param>
         /// <param name="length">number of items to return.</param>
-        /// <returns></returns>
+        /// <returns>Paged IQueryable object.</returns>
         public static IQueryable<T> PageByIndex<T>(this IQueryable<T> value, int? startIndex, int? length)
         {
             if (startIndex != null)
@@ -402,99 +399,20 @@ namespace System
             return f => false;
         }
 
-        public static Expression<Func<T, bool>> Or<T>(this Expression<Func<T, bool>> expr1,
-                                                            Expression<Func<T, bool>> expr2)
+        public static Expression<Func<T, bool>> Or<T>(
+            this Expression<Func<T, bool>> expr1,
+            Expression<Func<T, bool>> expr2)
         {
             var invokedExpr = Expression.Invoke(expr2, expr1.Parameters.Cast<Expression>());
-            return Expression.Lambda<Func<T, bool>>
-                  (Expression.OrElse(expr1.Body, invokedExpr), expr1.Parameters);
+            return Expression.Lambda<Func<T, bool>>(Expression.OrElse(expr1.Body, invokedExpr), expr1.Parameters);
         }
 
-        public static Expression<Func<T, bool>> And<T>(this Expression<Func<T, bool>> expr1,
-                                                             Expression<Func<T, bool>> expr2)
+        public static Expression<Func<T, bool>> And<T>(
+            this Expression<Func<T, bool>> expr1,
+            Expression<Func<T, bool>> expr2)
         {
             var invokedExpr = Expression.Invoke(expr2, expr1.Parameters.Cast<Expression>());
             return Expression.Lambda<Func<T, bool>>(Expression.AndAlso(expr1.Body, invokedExpr), expr1.Parameters);
         }
-    }
-
-    public static class ProcessExtensions
-    {
-#if DEBUG
-
-        /// <summary>
-        /// A utility class to determine a process parent.
-        /// http://stackoverflow.com/a/3346055
-        /// </summary>
-        [StructLayout(LayoutKind.Sequential)]
-        public struct ParentProcessUtilities
-        {
-            // These members must match PROCESS_BASIC_INFORMATION
-            internal IntPtr Reserved1;
-
-            internal IntPtr PebBaseAddress;
-
-            internal IntPtr Reserved2_0;
-
-            internal IntPtr Reserved2_1;
-
-            internal IntPtr UniqueProcessId;
-
-            internal IntPtr InheritedFromUniqueProcessId;
-
-            [DllImport("ntdll.dll")]
-            private static extern int NtQueryInformationProcess(
-                IntPtr processHandle,
-                int processInformationClass,
-                ref ParentProcessUtilities processInformation,
-                int processInformationLength,
-                out int returnLength);
-
-            /// <summary>
-            /// Gets the parent process of the current process.
-            /// </summary>
-            /// <returns>An instance of the Process class.</returns>
-            public static Process GetParentProcess()
-            {
-                return GetParentProcess(Process.GetCurrentProcess().Handle);
-            }
-
-            /// <summary>
-            /// Gets the parent process of specified process.
-            /// </summary>
-            /// <param name="id">The process id.</param>
-            /// <returns>An instance of the Process class.</returns>
-            public static Process GetParentProcess(int id)
-            {
-                Process process = Process.GetProcessById(id);
-                return GetParentProcess(process.Handle);
-            }
-
-            /// <summary>
-            /// Gets the parent process of a specified process.
-            /// </summary>
-            /// <param name="handle">The process handle.</param>
-            /// <returns>An instance of the Process class.</returns>
-            public static Process GetParentProcess(IntPtr handle)
-            {
-                ParentProcessUtilities pbi = new ParentProcessUtilities();
-                int status = NtQueryInformationProcess(handle, 0, ref pbi, Marshal.SizeOf(pbi), out var returnLength);
-                if (status != 0)
-                {
-                    throw new Win32Exception(status);
-                }
-
-                try
-                {
-                    return Process.GetProcessById(pbi.InheritedFromUniqueProcessId.ToInt32());
-                }
-                catch (ArgumentException)
-                {
-                    // not found
-                    return null;
-                }
-            }
-        }
-#endif
     }
 }

--- a/src/Acoustics.Shared/Extensions/ProcessExtensions.cs
+++ b/src/Acoustics.Shared/Extensions/ProcessExtensions.cs
@@ -1,0 +1,110 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ProcessExtensions.cs" company="QutEcoacoustics">
+// All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
+// </copyright>
+// <summary>
+//   Defines the Utilities type.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace System
+{
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.Runtime.InteropServices;
+    using static Acoustics.Shared.AppConfigHelper;
+
+    public static class ProcessExtensions
+    {
+        /// <summary>
+        /// A utility class to determine a process parent.
+        /// http://stackoverflow.com/a/3346055.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ParentProcessUtilities
+        {
+#if DEBUG
+            #pragma warning disable SA1310
+            // These members must match PROCESS_BASIC_INFORMATION
+            internal IntPtr Reserved1;
+
+            internal IntPtr PebBaseAddress;
+
+            internal IntPtr Reserved2_0;
+
+            internal IntPtr Reserved2_1;
+
+            internal IntPtr UniqueProcessId;
+
+            internal IntPtr InheritedFromUniqueProcessId;
+            #pragma warning restore
+
+            // TODO This import is windows only, replace with .NET Core API
+            [DllImport("ntdll.dll")]
+            private static extern int NtQueryInformationProcess(
+                IntPtr processHandle,
+                int processInformationClass,
+                ref ParentProcessUtilities processInformation,
+                int processInformationLength,
+                out int returnLength);
+
+            #pragma warning disable SA1202
+            /// <summary>
+            /// !WARNING Windows OS only
+            /// Gets the parent process of the current process.
+            /// Linux support blocked by https://github.com/dotnet/runtime/issues/24423.
+            /// </summary>
+            /// <returns>An instance of the Process class.</returns>
+            public static Process GetParentProcess()
+            {
+                return GetParentProcess(Process.GetCurrentProcess().Handle);
+            }
+
+            /// <summary>
+            /// !WARNING Windows OS only
+            /// Gets the parent process of specified process.
+            /// </summary>
+            /// <param name="id">The process id.</param>
+            /// <returns>An instance of the Process class.</returns>
+            public static Process GetParentProcess(int id)
+            {
+                Process process = Process.GetProcessById(id);
+                return GetParentProcess(process.Handle);
+            }
+
+            /// <summary>
+            /// !WARNING Windows OS only
+            /// Gets the parent process of a specified process.
+            /// </summary>
+            /// <param name="handle">The process handle.</param>
+            /// <returns>An instance of the Process class.</returns>
+            public static Process GetParentProcess(IntPtr handle)
+            {
+                if (!IsWindows)
+                {
+                    return null;
+                }
+
+                ParentProcessUtilities pbi = default;
+
+                int status = NtQueryInformationProcess(handle, 0, ref pbi, Marshal.SizeOf(pbi), out var _);
+                if (status != 0)
+                {
+                    throw new Win32Exception(status);
+                }
+
+                try
+                {
+                    return Process.GetProcessById(pbi.InheritedFromUniqueProcessId.ToInt32());
+                }
+                catch (ArgumentException)
+                {
+                    // not found
+                    return null;
+                }
+            }
+            #pragma warning restore
+#endif
+        }
+    }
+}

--- a/src/Acoustics.Shared/Extensions/SystemExtensions.cs
+++ b/src/Acoustics.Shared/Extensions/SystemExtensions.cs
@@ -1,5 +1,5 @@
 // --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ExtensionsGeneral.cs" company="QutEcoacoustics">
+// <copyright file="SystemExtensions.cs" company="QutEcoacoustics">
 // All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
 // </copyright>
 // <summary>
@@ -20,7 +20,7 @@ namespace System
     using System.Text;
     using System.Text.RegularExpressions;
 
-    public static class ExtensionsGeneral
+    public static class SystemExtensions
     {
         /// <summary>
         /// Gets ExecutingDirectory.

--- a/src/AnalysisPrograms/Production/MainEntryUtilities.cs
+++ b/src/AnalysisPrograms/Production/MainEntryUtilities.cs
@@ -279,7 +279,11 @@ previously found that the AP install is corrupt. Try installing AP again.
 
             // if Michael is debugging with visual studio, this will prevent the window closing.
             Process parentProcess = ProcessExtensions.ParentProcessUtilities.GetParentProcess();
-            if (parentProcess.ProcessName == "devenv")
+            if (parentProcess == null)
+            {
+                LoggedConsole.WriteWarnLine("WARNING: Unable to detect parent process, this is a windows specific tool.");
+            }
+            else if (parentProcess.ProcessName == "devenv")
             {
                 LoggedConsole.WriteSuccessLine("FINISHED: Press RETURN key to exit.");
                 Console.ReadLine();

--- a/tests/Acoustics.Test/AnalysisPrograms/Production/MainEntryUtilitiesTests.cs
+++ b/tests/Acoustics.Test/AnalysisPrograms/Production/MainEntryUtilitiesTests.cs
@@ -1,0 +1,23 @@
+// <copyright file="MainEntryUtilitiesTests.cs" company="QutEcoacoustics">
+// All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
+// </copyright>
+
+namespace Acoustics.Test.AnalysisPrograms.Production
+{
+    using System;
+    using Acoustics.Test.TestHelpers;
+    using global::AnalysisPrograms;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class MainEntryUtilitiesTests
+    {
+#if DEBUG
+        [TestMethod]
+        public void TestHangBeforeExitDoesNotThrowException()
+        {
+            Assertions.DoesNotThrow<NullReferenceException>(() => MainEntry.HangBeforeExit());
+        }
+#endif
+    }
+}

--- a/tests/Acoustics.Test/Shared/Extensions/ProcessExtensionsTests.cs
+++ b/tests/Acoustics.Test/Shared/Extensions/ProcessExtensionsTests.cs
@@ -4,6 +4,7 @@
 
 namespace Acoustics.Test.Shared.Extensions
 {
+#if DEBUG
     using Acoustics.Test.TestHelpers;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using static System.ProcessExtensions.ParentProcessUtilities;
@@ -23,4 +24,5 @@ namespace Acoustics.Test.Shared.Extensions
             Assert.IsNull(GetParentProcess());
         }
     }
+#endif
 }

--- a/tests/Acoustics.Test/Shared/Extensions/ProcessExtensionsTests.cs
+++ b/tests/Acoustics.Test/Shared/Extensions/ProcessExtensionsTests.cs
@@ -1,0 +1,26 @@
+// <copyright file="ProcessExtensionsTests.cs" company="QutEcoacoustics">
+// All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
+// </copyright>
+
+namespace Acoustics.Test.Shared.Extensions
+{
+    using Acoustics.Test.TestHelpers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using static System.ProcessExtensions.ParentProcessUtilities;
+
+    [TestClass]
+    public class ProcessExtensionsTests
+    {
+        [PlatformSpecificTestMethod("Windows", Reason = "https://github.com/dotnet/runtime/issues/24423")]
+        public void TestGetParentProcessReturnsProcessOnWindows()
+        {
+            Assert.IsNotNull(GetParentProcess());
+        }
+
+        [PlatformSpecificTestMethod("!Windows", Reason = "https://github.com/dotnet/runtime/issues/24423")]
+        public void TestGetParentProcessReturnsNullWhenNotWindows()
+        {
+            Assert.IsNull(GetParentProcess());
+        }
+    }
+}

--- a/tests/Acoustics.Test/TestHelpers/Assertions.cs
+++ b/tests/Acoustics.Test/TestHelpers/Assertions.cs
@@ -15,6 +15,12 @@ namespace Acoustics.Test.TestHelpers
 
     public static class Assertions
     {
+        public enum DiffStyle
+        {
+            Full,
+            Minimal,
+        }
+
         [DebuggerHidden]
         public static void AreEqual(this Assert assert, long expected, long actual, long delta, string message = null)
         {
@@ -282,12 +288,6 @@ namespace Acoustics.Test.TestHelpers
                 $"String\n{value}\n should not contain `{substring}`. {message}");
         }
 
-        public enum DiffStyle
-        {
-            Full,
-            Minimal,
-        }
-
         public static void StringEqualWithDiff(this Assert assert, string expectedValue, string actualValue)
         {
             ShouldEqualWithDiff(actualValue, expectedValue, DiffStyle.Full, Console.Out);
@@ -306,6 +306,25 @@ namespace Acoustics.Test.TestHelpers
         public static void ShouldEqualWithDiff(this string actualValue, string expectedValue, DiffStyle diffStyle)
         {
             ShouldEqualWithDiff(actualValue, expectedValue, diffStyle, Console.Out);
+        }
+
+        public static void DoesNotThrow<T>(Action expressionUnderTest, string exceptionMessage = "Expected exception was thrown by target of invocation.")
+        where T : Exception
+        {
+            try
+            {
+                expressionUnderTest();
+            }
+            catch (T)
+            {
+                Assert.Fail(exceptionMessage);
+            }
+            catch (Exception)
+            {
+                Assert.IsTrue(true);
+            }
+
+            Assert.IsTrue(true);
         }
 
         public static void ShouldEqualWithDiff(this string actualValue, string expectedValue, DiffStyle diffStyle, TextWriter output)


### PR DESCRIPTION
# Process Extension

Wrapped windows only software for retrieving parent process.

## Changes

- Renamed `ExtensionsSystem.cs` to `ExtensionsGeneral.cs`
- Removed warnings from `ExtensionsGeneral.cs` file
- Extracted `ProcessExtensions` class to separate file
- Return null when non windows computer attempts to retrieve parent process
- Updated VSCode tasks

## Issues

- May be possible to enable retrieval of parent process in future using .NET Core API: https://github.com/dotnet/runtime/issues/24423