### PR TITLE
Fixed bug in when removing enclosed events

### DIFF
--- a/src/AnalysisConfigFiles/RecognizerConfigFiles/Towsey.NinoxBoobook.yml
+++ b/src/AnalysisConfigFiles/RecognizerConfigFiles/Towsey.NinoxBoobook.yml
@@ -68,7 +68,7 @@ PostProcessing:
     #    MaxActivityDecibels: 12
     
     # 6: In the case of sets of nested/enclosed events, filter/remove all but the outermost event. 
-    RemoveTemporallyEnclosedEvents: true
+    RemoveEnclosedEvents: true
 
 # Options to save results files
 # 1: Available options for saving spectrograms (case-sensitive): [False/Never | True/Always | WhenEventsDetected]

--- a/src/AnalysisConfigFiles/RecognizerConfigFiles/Towsey.NinoxStrenua.yml
+++ b/src/AnalysisConfigFiles/RecognizerConfigFiles/Towsey.NinoxStrenua.yml
@@ -78,7 +78,7 @@ PostProcessing:
         MaxActivityDecibels: null
 
     # 6: In the case of sets of nested/enclosed events, filter/remove all but the outermost event. 
-    RemoveTemporallyEnclosedEvents: true
+    RemoveEnclosedEvents: true
 
 
 # Various options to save results files

--- a/src/AnalysisPrograms/Recognizers/GenericRecognizer.cs
+++ b/src/AnalysisPrograms/Recognizers/GenericRecognizer.cs
@@ -154,18 +154,19 @@ namespace AnalysisPrograms.Recognizers
                 postEvents.AddRange(ppEvents);
             }
 
-            // Running profiles with multiple dB thresholds can produce enclosed or temporally nested (Russian doll) events.
-            // Remove all but the outermost event.
-            if (configuration.PostProcessing.RemoveTemporallyEnclosedEvents)
+            // Running profiles with multiple dB thresholds can produce enclosed/nested events.
+            // Remove all but the outermost events.
+            if (configuration.PostProcessing.RemoveEnclosedEvents)
             {
-                Log.Debug($"\nREMOVE EVENTS ENCLOSED BY LONGER EVENTS.");
+                Log.Debug($"\nREMOVE ENCLOSED EVENTS.");
                 Log.Debug($"Event count BEFORE removing enclosed events = {postEvents.Count}.");
                 results.NewEvents = CompositeEvent.RemoveEnclosedEvents(postEvents);
                 Log.Debug($"Event count AFTER  removing enclosed events = {postEvents.Count}.");
             }
             else
             {
-                Log.Debug($"\nEVENTS ENCLOSED BY LONGER EVENTS WERE NOT REMOVED.");
+                Log.Debug($"\nENCLOSED EVENTS WERE NOT REMOVED - {postEvents.Count} events returned.");
+                results.NewEvents = postEvents;
             }
 
             // Write out the events to log.
@@ -176,7 +177,7 @@ namespace AnalysisPrograms.Recognizers
                 {
                     counter++;
                     var spEvent = (SpectralEvent)ev;
-                    Log.Debug($"  Event[{counter}]: Start={spEvent.EventStartSeconds:f1}; Duration={spEvent.EventDurationSeconds:f2}; Bandwidth={spEvent.BandWidthHertz} Hz");
+                    Log.Debug($"  Event[{counter}]: Start={spEvent.EventStartSeconds:f1}; End={spEvent.EventEndSeconds:f1}; Duration={spEvent.EventDurationSeconds:f2}; Bandwidth={spEvent.BandWidthHertz} Hz");
                 }
             }
 

--- a/src/AudioAnalysisTools/Events/Types/EventPostProcessing.cs
+++ b/src/AudioAnalysisTools/Events/Types/EventPostProcessing.cs
@@ -181,7 +181,7 @@ namespace AudioAnalysisTools.Events.Types
             /// Russian doll events!
             /// Setting this boolean true removes all but the outermost of any set of encloseed events.
             /// </summary>
-            public bool RemoveTemporallyEnclosedEvents { get; set; }
+            public bool RemoveEnclosedEvents { get; set; }
         }
 
         /// <summary>


### PR DESCRIPTION


# Fixed bug in when removing enclosed events

Also changed name of parameter RemoveTemporallyEnclosedEvents to RemoveEnclosedEvents.

## Changes

- Renamed RemoveTemporallyEnclosedEvents  to RemoveEnclosedEvents 
- And, actually returned post-processed events if RemoveEnclosedEvents  is `false` (rather than returning the raw results without any post-processing)

## Issues

Any recogniser built on new setting will need to be adjusted

## Visual Changes

N/A
