### PR TITLE
Fix bug in EventFilters.cs

### DIFF
--- a/src/AudioAnalysisTools/Events/EventFilters.cs
+++ b/src/AudioAnalysisTools/Events/EventFilters.cs
@@ -256,9 +256,6 @@ namespace AudioAnalysisTools.Events
                     }
                 }
 
-                string formatString = "{0:f2}";
-                Log.Debug($" Event[{count}] actual periods: {actualPeriodSeconds.JoinFormatted(", ", formatString)}");
-
                 // reject composite events whose total syllable count exceeds the user defined max.
                 if (syllableCount > maxSyllableCount)
                 {
@@ -276,6 +273,10 @@ namespace AudioAnalysisTools.Events
                 }
                 else
                 {
+                    // There are two or more syllables/events.
+                    string formatString = "{0:f2}";
+                    Log.Debug($" Event[{count}] actual periods: {actualPeriodSeconds.JoinFormatted(", ", formatString)}");
+
                     // If there are only two events, with one interval, THEN ...
                     var actualAvPeriod = actualPeriodSeconds[0];
 


### PR DESCRIPTION
See Issue #466 - Fix bug in EventFilters.cs

## Changes
Shifted two lines of code to correct location i.e. after necessary checks have determined the list contains something to write.

## Final Checklist
-   [ ] Assign reviewers if you have permission
-   [ ] Assign labels if you have permission
-   [ ] Link issues related to PR
-   [ ] Link any PRs or issues blocking this PR from being merged
-   [ ] Remove/Reduce warnings from edited files
-   [X ] no unit tests affected.

