### PR TITLE
Fixes bug in multi recogniser

### DIFF
--- a/src/AP.VersionBuild.targets
+++ b/src/AP.VersionBuild.targets
@@ -5,7 +5,7 @@
   <!-- Register our task that as something to run before standard build target -->
   <Target Name="APVersionBeforeBuild" BeforeTargets="PrepareForBuild">
     <!-- <Message Text="[APVersionBeforeBuild] Debug: $(RuntimeIdentifier)" Importance="High" /> -->
-    <Exec Command="pwsh –NonInteractive -noprofile $(ProjectDir)../git_version.ps1 -configuration $(Configuration) -self_contained $(SelfContained) -runtime_identifier '$(RuntimeIdentifier)'" ConsoleToMSBuild="True" EchoOff="false" StandardOutputImportance="low">
+    <Exec Command="pwsh –NonInteractive -noprofile $(ProjectDir)../git_version.ps1 -configuration $(Configuration) -self_contained $(SelfContained) -runtime_identifier &quot;$(RuntimeIdentifier)&quot; -target_framework &quot;$(TargetFramework.ToLowerInvariant())&quot;" ConsoleToMSBuild="True" EchoOff="false" StandardOutputImportance="low">
       <Output TaskParameter="ConsoleOutput" ItemName="VersionMetadata" />
     </Exec>
     <!-- <Message Text="[APVersionBeforeBuild] %(VersionMetadata.Identity)" Importance="High" /> -->

--- a/src/Acoustics.Shared/ConfigFile/Config.cs
+++ b/src/Acoustics.Shared/ConfigFile/Config.cs
@@ -7,6 +7,7 @@ namespace Acoustics.Shared.ConfigFile
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.IO;
     using Acoustics.Shared.Contracts;
 
     public class Config : IConfig
@@ -46,6 +47,8 @@ namespace Acoustics.Shared.ConfigFile
         }
 
         public string ConfigPath { get; set; }
+
+        public string ConfigDirectory => Path.GetDirectoryName(this.ConfigPath);
 
         /// <summary>
         /// Gets or sets the generic object graph that mirrors the configuration.

--- a/src/Acoustics.Shared/Extensions/ExtensionsString.cs
+++ b/src/Acoustics.Shared/Extensions/ExtensionsString.cs
@@ -402,6 +402,16 @@ namespace System
             return !string.IsNullOrWhiteSpace(str);
         }
 
+        public static string StripEnd(this string str, string suffix, StringComparison comparison = default)
+        {
+            if (suffix != null && str.EndsWith(suffix, comparison))
+            {
+                return str.Substring(0, str.Length - suffix.Length);
+            }
+
+            return str;
+        }
+
         public static string NormalizeToCrLf(this string str)
         {
             string normalized = Regex.Replace(str, @"\r\n|\n\r|\n|\r", "\r\n");

--- a/src/Acoustics.Shared/Extensions/FileInfoExtensions.cs
+++ b/src/Acoustics.Shared/Extensions/FileInfoExtensions.cs
@@ -187,6 +187,13 @@ namespace System
             return info;
         }
 
+        public static FileInfo CopyTo(this FileInfo source, DirectoryInfo dest)
+        {
+            var result = Path.Combine(dest.FullName, source.Name);
+            source.CopyTo(result);
+            return result.ToFileInfo();
+        }
+
         public static string BaseName(this FileInfo file)
         {
             return Path.GetFileNameWithoutExtension(file.Name);

--- a/src/AnalysisBase/AnalyzerConfig.cs
+++ b/src/AnalysisBase/AnalyzerConfig.cs
@@ -15,7 +15,7 @@ namespace AnalysisBase
         [Obsolete("The AnalysisName property is no longer used")]
         public string AnalysisName { get; set; }
 
-        public double EventThreshold { get; set; } = EventThresholdDefault;
+        public virtual double EventThreshold { get; set; } = EventThresholdDefault;
 
         /// <summary>
         /// Gets or sets the length of audio block to process.

--- a/src/AnalysisConfigFiles/.vscode/settings.json
+++ b/src/AnalysisConfigFiles/.vscode/settings.json
@@ -2,5 +2,6 @@
     "cSpell.words": [
         "Nyquist",
         "Resample"
-    ]
+    ],
+    "python.pythonPath": "C:\\Python37\\python.exe"
 }

--- a/src/AnalysisConfigFiles/RecognizerConfigFiles/QUT.MultiRecognizer.yml
+++ b/src/AnalysisConfigFiles/RecognizerConfigFiles/QUT.MultiRecognizer.yml
@@ -8,7 +8,7 @@
 # LIST OF REQUIRED SPECIES RECOGNISERS
 # The items in this list need to match the value for `AnalysisName` in each of the individual species config files.
 # Note also, that the config file paths are resolved by appending '.yml' to the end of each item in the species list.
-SpeciesList:
+AnalysisNames:
 #  - Towsey.CriniaRemota
   - Towsey.LimnodynastesConvex
 #  - Towsey.LitoriaBicolor
@@ -24,9 +24,6 @@ SpeciesList:
 #  - Towsey.UperoleiaInundata
 #  - Towsey.UperoleiaLithomoda
 
-# Standard settings
-EventThreshold: 0.2
-
 
 ## Specifically for AnalyzeLongRecording
 # SegmentDuration: units=seconds;
@@ -35,7 +32,7 @@ SegmentDuration: 60
 SegmentOverlap: 0
 # Available options (case-sensitive): [False/Never | True/Always | WhenEventsDetected]
 SaveIntermediateWavFiles: Never
-# If `true` saves a data into a seperate file every `SegmentDuration` seconds. Accepts a boolean value: [false|true]
+# If `true` saves a data into a separate file every `SegmentDuration` seconds. Accepts a boolean value: [false|true]
 SaveIntermediateCsvFiles: false
 # Available options (case-sensitive): [False/Never | True/Always | WhenEventsDetected]
 SaveSonogramImages: True

--- a/src/AnalysisPrograms/AnalyseLongRecordings/AnalyseLongRecording.cs
+++ b/src/AnalysisPrograms/AnalyseLongRecordings/AnalyseLongRecording.cs
@@ -119,7 +119,7 @@ namespace AnalysisPrograms.AnalyseLongRecordings
 
             bool filenameDate = configuration.RequireDateInFilename;
 
-            if (configuration[AnalysisKeys.AnalysisName].IsNotWhitespace())
+            if (configuration.AnalysisName.IsNotWhitespace())
             {
                 Log.Warn("Your config file has `AnalysisName` set - this property is deprecated and ignored");
             }

--- a/src/AnalysisPrograms/Recognizers/Base/MultiRecognizer.cs
+++ b/src/AnalysisPrograms/Recognizers/Base/MultiRecognizer.cs
@@ -216,6 +216,13 @@ namespace AnalysisPrograms.Recognizers.Base
                 {
                     MultiRecognizerConfig config = (MultiRecognizerConfig)eventConfig;
 
+                    if (config.AnalysisNames is null or { Length: 0 })
+                    {
+                        throw new ConfigFileException(
+                            $"{ nameof(this.AnalysisNames)} cannot be null or empty. It should be a list with at least one config file in it.",
+                            config.ConfigPath);
+                    }
+
                     // load the other config files
                     this.Analyses =
                         config

--- a/src/AnalysisPrograms/Recognizers/Base/MultiRecognizer.cs
+++ b/src/AnalysisPrograms/Recognizers/Base/MultiRecognizer.cs
@@ -208,7 +208,7 @@ namespace AnalysisPrograms.Recognizers.Base
             return trackImage;
         }
 
-        public class MultiRecognizerConfig : AnalyzerConfig
+        public class MultiRecognizerConfig : RecognizerConfig
         {
             public MultiRecognizerConfig()
             {

--- a/src/AssemblyMetadata.cs.template
+++ b/src/AssemblyMetadata.cs.template
@@ -44,6 +44,7 @@ namespace AnalysisPrograms
         public const bool CompiledAsSelfContained = ${self_contained};
         public const string CompiledRuntimeIdentifer = "${runtime_identifier}";
         public const string CompiledConfiguration = "${configuration}";
+        public const string CompiledTargetFramework = "${target_framework}";
 
         public static readonly Version Version = new Version("${version}");
     }

--- a/src/git_version.ps1
+++ b/src/git_version.ps1
@@ -5,6 +5,7 @@ param(
     [string]$configuration,
     [string]$self_contained,
     [string]$runtime_identifier,
+    [string]$target_framework,
     [switch]$set_ci = $false,
     [switch]$json = $false,
     [switch]$env_vars = $false,
@@ -144,7 +145,7 @@ elseif ($json) {
 }
 elseif ($env_vars) {
     # https://github.com/PowerShell/PowerShell/issues/5543
-    # Due to a bug with set-content, it cna't bind to the property for a value in
+    # Due to a bug with set-content, it can't bind to the property for a value in
     # an object, which makes the pipeline version rather intolerable.
     # Hence we're adding a toString() to our pscustomobject that ensures only
     # the value is represented when Set-Content calls toString

--- a/tests/Acoustics.Test/AnalysisPrograms/Recognizers/MultiRecogniserTests.cs
+++ b/tests/Acoustics.Test/AnalysisPrograms/Recognizers/MultiRecogniserTests.cs
@@ -1,0 +1,110 @@
+// <copyright file="MultiRecogniserTests.cs" company="QutEcoacoustics">
+// All code in this file and all associated files are the copyright and property of the QUT Ecoacoustics Research Group (formerly MQUTeR, and formerly QUT Bioacoustics Research Group).
+// </copyright>
+
+namespace Acoustics.Test.AnalysisPrograms.Recognizers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Acoustics.Shared.ConfigFile;
+    using Acoustics.Test.TestHelpers;
+    using AudioAnalysisTools.Events;
+    using global::AnalysisPrograms.Recognizers;
+    using global::AnalysisPrograms.Recognizers.Base;
+    using global::AudioAnalysisTools.Events;
+    using global::AudioAnalysisTools.WavTools;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using MoreLinq.Extensions;
+
+    [TestClass]
+    public class MultiRecogniserTests : OutputDirectoryTest
+    {
+        private static readonly FileInfo TestAsset = PathHelper.ResolveAsset("Recordings", "Powerful3AndBoobook0_ksh3_1773_510819_20171109_174311_30_0.wav");
+        private static readonly FileInfo ConfigFile1 = PathHelper.ResolveConfigFile("RecognizerConfigFiles", "Towsey.NinoxStrenua.yml");
+        private static readonly FileInfo ConfigFile2 = PathHelper.ResolveConfigFile("RecognizerConfigFiles", "Towsey.NinoxBoobook.yml");
+        private static readonly AudioRecording Recording = new AudioRecording(TestAsset);
+        private static readonly MultiRecognizer Recognizer = new MultiRecognizer();
+
+        [TestMethod]
+        public void MultiRecogniserDeserializationAcceptsEitherFilenameOrAnalysisName()
+        {
+            var thisTestBoobookConfig = ConfigFile2.CopyTo(this.TestOutputDirectory);
+            var configFileFromBuildDir = Path.Combine(PathHelper.TestBuild, "ConfigFiles", "RecognizerConfigFiles", "Towsey.NinoxStrenua.yml");
+
+            var literalConfig = $@"
+AnalysisNames:
+    - Towsey.NinoxStrenua.yml
+    - Towsey.NinoxStrenua
+    - {ConfigFile1.FullName}
+    - Towsey.NinoxBoobook.yml
+    - ./Towsey.NinoxBoobook.yml
+";
+            var configFile = this.TestOutputDirectory.CombineFile("QUT.MultiRecognizer.yml");
+
+            File.WriteAllText(configFile.FullName, literalConfig);
+
+            var config = ConfigFile.Deserialize<MultiRecognizer.MultiRecognizerConfig>(configFile);
+
+            Assert.AreEqual(5, config.Analyses.Length);
+
+            // first three should resolve to "default" configs from config file folder
+            // first two, resolve to copy with built files, last, is an absolute path reference to source config file
+            var first3Recognisers = config.Analyses.Take(3).Select(x => x.Recognizer).ToList();
+            CollectionAssert.AllItemsAreInstancesOfType(first3Recognisers, typeof(NinoxStrenua));
+            var first3Configs = config.Analyses.Take(3).Select(x => x.Configuration).ToList();
+            CollectionAssert.AllItemsAreInstancesOfType(first3Configs, typeof(NinoxStrenua.NinoxStrenuaConfig));
+            CollectionAssert.AreEqual(
+                first3Configs.Select(x => x.ConfigPath).ToArray(),
+                new[]
+                {
+                    configFileFromBuildDir,
+                    configFileFromBuildDir,
+                    ConfigFile1.FullName,
+                });
+
+            // last two should be resolved relative to the config file
+            var last2Recognisers = config.Analyses.Skip(3).Select(x => x.Recognizer).ToList();
+            CollectionAssert.AllItemsAreInstancesOfType(last2Recognisers, typeof(NinoxBoobook));
+            var last2Configs = config.Analyses.Skip(3).Select(x => x.Configuration).ToList();
+            CollectionAssert.AllItemsAreInstancesOfType(last2Configs, typeof(NinoxBoobook.NinoxBoobookConfig));
+            CollectionAssert.AreEqual(
+                last2Configs.Select(x => x.ConfigPath).ToArray(),
+                new[]
+                {
+                    thisTestBoobookConfig.FullName,
+                    thisTestBoobookConfig.FullName,
+                });
+        }
+
+        [TestMethod]
+        public void MultiRecogniserWorks()
+        {
+            var literalConfig = $@"
+AnalysisNames:
+    - Towsey.NinoxStrenua
+    - Towsey.NinoxBoobook
+";
+            var configFile = this.TestOutputDirectory.CombineFile("QUT.MultiRecognizer.yml");
+            File.WriteAllText(configFile.FullName, literalConfig);
+            var config = Recognizer.ParseConfig(configFile);
+
+            var results = Recognizer.Recognize(
+                Recording,
+                config,
+                TimeSpan.Zero,
+                null,
+                this.TestOutputDirectory,
+                null);
+
+            // basically checking we have a mix of each type of event - we really don't care how many of each since
+            // this test is not testing the recognisers themselves
+            Assert.IsTrue(results.GetAllEvents().Count() > 2);
+            Assert.IsTrue(results.GetAllEvents().Where(x => (x as SpectralEvent)?.Name == "NinoxBoobook").Count() > 1);
+            Assert.IsTrue(results.GetAllEvents().Where(x => (x as SpectralEvent)?.Name == "NinoxStrenua").Count() > 1);
+        }
+    }
+}

--- a/tests/Acoustics.Test/AnalysisPrograms/Recognizers/MultiRecogniserTests.cs
+++ b/tests/Acoustics.Test/AnalysisPrograms/Recognizers/MultiRecogniserTests.cs
@@ -81,6 +81,23 @@ AnalysisNames:
         }
 
         [TestMethod]
+        public void MultiRecogniserDeserializationValidatesAnalysisNamesArePresent()
+        {
+            var literalConfig = $@"
+AnalysisNames: ~
+";
+            var configFile = this.TestOutputDirectory.CombineFile("QUT.MultiRecognizer.yml");
+
+            File.WriteAllText(configFile.FullName, literalConfig);
+
+            var exception = Assert.ThrowsException<ConfigFileException>(
+                () => ConfigFile.Deserialize<MultiRecognizer.MultiRecognizerConfig>(configFile));
+            StringAssert.Contains(
+                exception.Message,
+                "AnalysisNames cannot be null or empty. It should be a list with at least one config file in it");
+        }
+
+        [TestMethod]
         public void MultiRecogniserWorks()
         {
             var literalConfig = $@"

--- a/tests/Acoustics.Test/TestHelpers/PathHelper.cs
+++ b/tests/Acoustics.Test/TestHelpers/PathHelper.cs
@@ -17,10 +17,24 @@ namespace Acoustics.Test.TestHelpers
     {
         private static TestContext testContext;
 
+        /// <value>
+        /// e.g. C:\Work\Github\audio-analysis\src\AnalysisPrograms\bin\Debug\net5.0 .
+        /// </value>
         public static string AnalysisProgramsBuild { get; private set; }
 
+        /// <value>
+        /// e.g. C:\Work\Github\audio-analysis\tests\Acoustics.Test\bin\Debug\net5.0 .
+        /// </value>
+        public static string TestBuild { get; private set; }
+
+        /// <value>
+        /// e.g. C:\Work\Github\audio-analysis\tests\Acoustics.Test\bin\Debug\net5.0 .
+        /// </value>
         public static string SolutionRoot { get; private set; }
 
+        /// <value>
+        /// e.g. C:\Work\Github\audio-analysis .
+        /// </value>
         public static string TestResources { get; private set; }
 
         /// <summary>
@@ -37,6 +51,12 @@ namespace Acoustics.Test.TestHelpers
         public static FileInfo ResolveConfigFile(params string[] pathComponents)
         {
             pathComponents = new[] { SolutionRoot, "src", "AnalysisConfigFiles" }.Concat(pathComponents).ToArray();
+            return new FileInfo(Path.Combine(pathComponents));
+        }
+
+        public static FileInfo ResolveConfigFileFromBuildDirectory(params string[] pathComponents)
+        {
+            pathComponents = new[] { AnalysisProgramsBuild, "ConfigFiles" }.Concat(pathComponents).ToArray();
             return new FileInfo(Path.Combine(pathComponents));
         }
 
@@ -153,7 +173,15 @@ namespace Acoustics.Test.TestHelpers
                 Meta.ProjectName,
                 "bin",
                 BuildMetadata.CompiledConfiguration,
-                "netcoreapp3.1",
+                BuildMetadata.CompiledTargetFramework,
+                BuildMetadata.CompiledAsSelfContained ? BuildMetadata.CompiledRuntimeIdentifer : string.Empty);
+            TestBuild = Path.Combine(
+                SolutionRoot,
+                "tests",
+                "Acoustics.Test",
+                "bin",
+                BuildMetadata.CompiledConfiguration,
+                BuildMetadata.CompiledTargetFramework,
                 BuildMetadata.CompiledAsSelfContained ? BuildMetadata.CompiledRuntimeIdentifer : string.Empty);
 
             testContext = context;


### PR DESCRIPTION
# Fixes bug in multi recogniser 

The multirecogniser was not outputting any events after the component recognizers detected events.  The fix was simply to ensure NewEvents were aggregated as well as old style AcousticEvents.

## Changes

Also:
- wrote tests for the multi recognizers
- ensured that multiple different ways of specifying sub-recognizers would work (name, soft-resolved config, absolute reference to files)
- also ensured configs were loaded before the main analysis starts - this should produce much nicer error messages and avoid cutting audio before telling the user about the inevitable failure.
- fixed the path to analysis programs in the test metdadata helper

## Issues

Fixes #97

## Visual Changes

N/A

## Final Checklist

-   [x] Assign reviewers if you have permission
-   [x] Assign labels if you have permission
-   [x] Link issues related to PR
-   [x] Link any PRs or issues blocking this PR from being merged
-   [x] Remove/Reduce warnings from edited files
-   [x] Unit tests have been added for changes
-   [ ] Ensure CI build is passing
